### PR TITLE
feat: support GitHub Copilot CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npx vibe-usage status       # Show config & detected tools
 |------|---------------|
 | Claude Code | `~/.claude/projects/` (tokens + sessions), `~/.claude/transcripts/` (sessions only) |
 | Codex CLI | `~/.codex/sessions/` |
+| GitHub Copilot CLI | `~/.copilot/session-state/*/events.jsonl` |
 | Gemini CLI | `~/.gemini/tmp/` |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/` |
@@ -41,7 +42,7 @@ npx vibe-usage status       # Show config & detected tools
 
 - Parses local session logs from each AI coding tool
 - Aggregates token usage into 30-minute buckets
-- Extracts session metadata from all 7 parsers: active time (sum of turn durations), total duration, message counts
+- Extracts session metadata from all 8 parsers: active time (sum of turn durations), total duration, message counts
 - Uploads buckets + sessions to your vibecafe.ai dashboard
 - Stateless: computes full totals from local logs each sync (idempotent, no state files)
 - For continuous syncing, use `npx vibe-usage daemon` or the [Vibe Usage Mac app](https://github.com/vibe-cafe/vibe-usage-app)

--- a/src/parsers/copilot-cli.js
+++ b/src/parsers/copilot-cli.js
@@ -1,0 +1,128 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { homedir } from 'node:os';
+import { aggregateToBuckets, extractSessions } from './index.js';
+
+const SESSION_STATE_DIR = join(homedir(), '.copilot', 'session-state');
+
+function findEventFiles(baseDir) {
+  const results = [];
+  if (!existsSync(baseDir)) return results;
+
+  try {
+    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const eventsFile = join(baseDir, entry.name, 'events.jsonl');
+      if (existsSync(eventsFile)) {
+        results.push({ filePath: eventsFile, sessionId: entry.name });
+      }
+    }
+  } catch {
+    return results;
+  }
+
+  return results;
+}
+
+function getProjectFromContext(context) {
+  const projectPath = context?.gitRoot || context?.cwd;
+  if (!projectPath) return 'unknown';
+
+  return basename(projectPath) || 'unknown';
+}
+
+/**
+ * Parse GitHub Copilot CLI session logs from ~/.copilot/session-state.
+ * Returns usage buckets from session shutdown summaries and session metadata
+ * from user/assistant message timings.
+ */
+export async function parse() {
+  const eventFiles = findEventFiles(SESSION_STATE_DIR);
+  if (eventFiles.length === 0) return { buckets: [], sessions: [] };
+
+  const entries = [];
+  const sessionEvents = [];
+
+  for (const { filePath, sessionId } of eventFiles) {
+    let content;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let currentProject = 'unknown';
+
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+
+      try {
+        const obj = JSON.parse(line);
+        const timestamp = obj.timestamp ? new Date(obj.timestamp) : null;
+        const hasTimestamp = timestamp && !isNaN(timestamp.getTime());
+
+        if (obj.type === 'session.start' || obj.type === 'session.resume') {
+          currentProject = getProjectFromContext(obj.data?.context);
+        }
+
+        if (hasTimestamp && obj.type === 'user.message') {
+          sessionEvents.push({
+            sessionId,
+            source: 'copilot-cli',
+            project: currentProject,
+            timestamp,
+            role: 'user',
+          });
+        }
+
+        if (hasTimestamp && obj.type === 'assistant.message') {
+          sessionEvents.push({
+            sessionId,
+            source: 'copilot-cli',
+            project: currentProject,
+            timestamp,
+            role: 'assistant',
+          });
+        }
+
+        if (obj.type !== 'session.shutdown' || !hasTimestamp) continue;
+
+        const modelMetrics = obj.data?.modelMetrics || {};
+        for (const [model, metrics] of Object.entries(modelMetrics)) {
+          const usage = metrics?.usage;
+          if (!usage) continue;
+
+          const totalInput = usage.inputTokens || 0;
+          const cachedRead = usage.cacheReadTokens || 0;
+          const cacheWrite = usage.cacheWriteTokens || 0;
+          const output = usage.outputTokens || 0;
+
+          if (totalInput === 0 && cachedRead === 0 && cacheWrite === 0 && output === 0) {
+            continue;
+          }
+
+          entries.push({
+            source: 'copilot-cli',
+            model,
+            project: currentProject,
+            timestamp,
+            // Copilot reports cache reads separately, but cache writes are part of
+            // regular input for this schema because buckets don't have a dedicated field.
+            inputTokens: Math.max(0, totalInput - cachedRead),
+            outputTokens: output,
+            cachedInputTokens: cachedRead,
+            reasoningOutputTokens: 0,
+          });
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return {
+    buckets: aggregateToBuckets(entries),
+    sessions: extractSessions(sessionEvents),
+  };
+}

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { parse as parseClaudeCode } from './claude-code.js';
 import { parse as parseCodex } from './codex.js';
+import { parse as parseCopilotCli } from './copilot-cli.js';
 import { parse as parseGeminiCli } from './gemini-cli.js';
 import { parse as parseOpencode } from './opencode.js';
 import { parse as parseOpenclaw } from './openclaw.js';
@@ -10,6 +11,7 @@ import { parse as parseKimiCode } from './kimi-code.js';
 export const parsers = {
   'claude-code': parseClaudeCode,
   'codex': parseCodex,
+  'copilot-cli': parseCopilotCli,
   'gemini-cli': parseGeminiCli,
   'opencode': parseOpencode,
   'openclaw': parseOpenclaw,

--- a/src/tools.js
+++ b/src/tools.js
@@ -14,6 +14,11 @@ export const TOOLS = [
     dataDir: join(homedir(), '.codex', 'sessions'),
   },
   {
+    name: 'GitHub Copilot CLI',
+    id: 'copilot-cli',
+    dataDir: join(homedir(), '.copilot', 'session-state'),
+  },
+  {
     name: 'Gemini CLI',
     id: 'gemini-cli',
     dataDir: join(homedir(), '.gemini', 'tmp'),


### PR DESCRIPTION
## Summary
- add a `copilot-cli` parser for `~/.copilot/session-state/*/events.jsonl`
- extract usage buckets from `session.shutdown` model metrics and session timings from user/assistant messages
- register GitHub Copilot CLI in tool detection and README

## Testing
- `node - <<'NODE' ... parse() ... NODE`
- `node ./bin/vibe-usage.js status`