### PR TITLE
fix: parse nested Kimi wire events for accurate token/session stats

### DIFF
--- a/src/parsers/kimi-code.js
+++ b/src/parsers/kimi-code.js
@@ -13,6 +13,25 @@ import { aggregateToBuckets, extractSessions } from './index.js';
 const KIMI_SESSIONS_DIR = join(homedir(), '.kimi', 'sessions');
 const KIMI_CONFIG = join(homedir(), '.kimi', 'kimi.json');
 
+function parseTimestamp(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') {
+    const ms = value > 1e12 ? value : value * 1000;
+    const date = new Date(ms);
+    return isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string') {
+    const asNumber = Number(value);
+    if (!Number.isNaN(asNumber)) {
+      const ms = asNumber > 1e12 ? asNumber : asNumber * 1000;
+      const date = new Date(ms);
+      return isNaN(date.getTime()) ? null : date;
+    }
+  }
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
 function findWireFiles(baseDir) {
   const results = [];
   if (!existsSync(baseDir)) return results;
@@ -85,32 +104,40 @@ export async function parse() {
       if (!line.trim()) continue;
       try {
         const obj = JSON.parse(line);
-        const type = obj.type;
-        const payload = obj.payload;
-        if (!payload) continue;
+        const message = obj.message && typeof obj.message === 'object' ? obj.message : null;
+        const type = message?.type || obj.type;
+        const payload = message?.payload ?? obj.payload;
+        if (!type || !payload || typeof payload !== 'object') continue;
 
-        if (payload.timestamp) lastTimestamp = payload.timestamp;
+        const eventTimestamp = parseTimestamp(obj.timestamp ?? payload.timestamp);
+        if (eventTimestamp) lastTimestamp = eventTimestamp;
         if (payload.model) currentModel = payload.model;
 
-        if (lastTimestamp) {
-          const evTs = new Date(lastTimestamp);
-          if (!isNaN(evTs.getTime())) {
-            const isUser = type === 'UserMessage' || type === 'user_message' || type === 'Input';
-            sessionEvents.push({
-              sessionId: filePath,
-              source: 'kimi-code',
-              project,
-              timestamp: evTs,
-              role: isUser ? 'user' : 'assistant',
-            });
-          }
+        const sessionTimestamp = eventTimestamp || lastTimestamp;
+        if (sessionTimestamp) {
+          const isUser =
+            type === 'UserMessage' ||
+            type === 'user_message' ||
+            type === 'Input' ||
+            type === 'TurnBegin';
+          sessionEvents.push({
+            sessionId: filePath,
+            source: 'kimi-code',
+            project,
+            timestamp: sessionTimestamp,
+            role: isUser ? 'user' : 'assistant',
+          });
         }
 
         if (type !== 'StatusUpdate') continue;
 
-        const tokenUsage = payload.token_usage;
+        const tokenUsage = payload.token_usage || payload.tokenUsage;
         if (!tokenUsage) continue;
-        if (!tokenUsage.input_other && !tokenUsage.output) continue;
+        const inputOther = tokenUsage.input_other || 0;
+        const output = tokenUsage.output || 0;
+        const cacheRead = tokenUsage.input_cache_read || 0;
+        const cacheCreation = tokenUsage.input_cache_creation || 0;
+        if (!inputOther && !output && !cacheRead && !cacheCreation) continue;
 
         const messageId = payload.message_id;
         if (messageId) {
@@ -118,16 +145,17 @@ export async function parse() {
           seenMessageIds.add(messageId);
         }
 
-        const ts = lastTimestamp ? new Date(lastTimestamp) : new Date();
+        const ts = eventTimestamp || lastTimestamp || new Date();
+        if (isNaN(ts.getTime())) continue;
 
         entries.push({
           source: 'kimi-code',
           model: currentModel,
           project,
           timestamp: ts,
-          inputTokens: tokenUsage.input_other || 0,
-          outputTokens: tokenUsage.output || 0,
-          cachedInputTokens: tokenUsage.input_cache_read || 0,
+          inputTokens: inputOther + cacheCreation,
+          outputTokens: output,
+          cachedInputTokens: cacheRead,
           reasoningOutputTokens: 0,
         });
       } catch {


### PR DESCRIPTION
## Summary
- Fix `kimi-code` parser to support current Kimi CLI wire format where events are nested under `message.type` / `message.payload` instead of top-level `type` / `payload`.
- Normalize Kimi timestamps (including epoch seconds with decimals) to valid JS `Date`, and skip invalid timestamps safely to avoid parser-wide failure.
- Improve token extraction robustness by accepting both `token_usage` and `tokenUsage`, counting cache-only updates, and mapping `input_cache_creation` into input tokens for usage accounting consistency.

## Why
Recent real-world Kimi session logs were not being parsed correctly because the parser assumed an older top-level event shape. This caused token/session undercounting (or zero counts). The change restores compatibility with actual Kimi wire logs and makes parsing resilient to timestamp/field variations.

## Validation
- Ran parser directly against local real Kimi data:
  - `kimi-code: 8 buckets, 3 sessions`
- Cross-checked parser totals against raw `wire.jsonl` aggregation:
  - input: `561926`
  - output: `62596`
  - cache read: `9735424`
  - values matched parser output after fix
- Ran full sync successfully:
  - parser recognized and uploaded Kimi data without errors

## Limitations / Not covered
- Session-level model identity is still not reliably available from Kimi session files (`wire.jsonl`/`state.json` do not provide a stable per-session model field in current observed data).
- We currently infer/use model only when present in event payload; if absent, fallback remains `unknown`.
- This PR does not change backend schema or add new session fields (e.g. `sessionModel`).
- This PR does not resolve historical data that was previously uploaded with undercounted Kimi stats; correcting history would require re-sync/backfill strategy.

## Scope
- Updated: `src/parsers/kimi-code.js`
- No backend/API contract changes

Made with [Cursor](https://cursor.com)