### PR TITLE
perf: gzip upload payload to reduce bandwidth ~94% (v0.7.9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ vibe-usage/
 │   │   └── hermes.js          # SQLite via child_process sqlite3
 │   ├── tools.js               # TOOLS[] registry + detectInstalledTools()
 │   ├── sync.js                # Orchestrator: parse all → batch upload buckets + sessions
-│   ├── api.js                 # HTTP client: ingest(), deleteAllData(), fetchSettings()
+│   ├── api.js                 # HTTP client: ingest() (gzip if ≥1KB), deleteAllData(), fetchSettings()
 │   ├── config.js              # ~/.vibe-usage/config.json (dev: config.dev.json)
 │   ├── init.js                # Setup flow (API key via prompt or --key flag, verify, initial sync, daemon install prompt)
 │   ├── daemon.js              # 5-minute sync loop (foreground)
@@ -39,7 +39,7 @@ vibe-usage/
 ## Key Conventions
 
 - **Pure ESM** (`"type": "module"`) — no CommonJS, no build step
-- **Zero dependencies** — only Node built-ins (fs, path, os, crypto, https, readline, child_process)
+- **Zero dependencies** — only Node built-ins (fs, path, os, crypto, https, readline, child_process, zlib)
 - **Stateless sync** — parsers compute full totals from raw logs each run; server upserts idempotently
 - **Stable hostname** — hostname is persisted in config at init; `sync.js` never re-reads `os.hostname()` after first capture. This prevents macOS mDNS hostname drift (e.g., `-2`, `-3` suffixes) from creating duplicate device entries in the DB.
 - **No TypeScript** — plain JavaScript throughout

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 - Parses local session logs from each AI coding tool
 - Aggregates token usage into 30-minute buckets
 - Extracts session metadata from all parsers: active time (AI generation time, excluding queue/TTFT wait), total duration, message counts
-- Uploads buckets + sessions to your vibecafe.ai dashboard
+- Uploads buckets + sessions to your vibecafe.ai dashboard (gzip-compressed when ≥ 1 KB, ~94% smaller)
 - Stateless: computes full totals from local logs each sync (idempotent, no state files)
 - For continuous syncing, use `npx @vibe-cafe/vibe-usage daemon` or the [Vibe Usage Mac app](https://github.com/vibe-cafe/vibe-usage-app)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-cafe/vibe-usage",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Track your AI coding tool token usage and sync to vibecafe.ai",
   "type": "module",
   "bin": {

--- a/src/api.js
+++ b/src/api.js
@@ -1,9 +1,11 @@
 import https from 'node:https';
 import http from 'node:http';
 import { URL } from 'node:url';
+import { gzipSync } from 'node:zlib';
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY = 1000;
+const GZIP_MIN_BYTES = 1024;
 
 export async function ingest(apiUrl, apiKey, buckets, opts, sessions) {
   let lastError;
@@ -30,18 +32,23 @@ function _send(apiUrl, apiKey, buckets, onProgress, sessions) {
     const url = new URL('/api/usage/ingest', apiUrl);
     const payload = { buckets };
     if (sessions && sessions.length > 0) payload.sessions = sessions;
-    const body = Buffer.from(JSON.stringify(payload));
+    const raw = Buffer.from(JSON.stringify(payload));
+    const useGzip = raw.length >= GZIP_MIN_BYTES;
+    const body = useGzip ? gzipSync(raw) : raw;
     const totalBytes = body.length;
     const mod = url.protocol === 'https:' ? https : http;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Length': totalBytes,
+    };
+    if (useGzip) headers['Content-Encoding'] = 'gzip';
 
     const req = mod.request(url, {
       method: 'POST',
       timeout: 60_000,
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Length': totalBytes,
-      },
+      headers,
     }, (res) => {
       let data = '';
       res.on('data', (chunk) => { data += chunk; });


### PR DESCRIPTION
## Summary
- CLI gzips the `POST /api/usage/ingest` body when it's ≥ 1 KB and sets `Content-Encoding: gzip`.
- Bumped to **v0.7.9** (patch).
- Pairs with vibe-cafe PR (https://github.com/vibe-cafe/vibe-cafe/pull/new/feat/ingest-gzip), which teaches the server to decompress.

## Why
`vibe-usage` is stateless by design — every sync re-aggregates the full local history and re-uploads it. As a user accumulates months of buckets that's a lot of redundant bytes, and the daemon syncs every 30 min. Token-bucket JSON is highly repetitive, so gzip is brutally effective:

| Payload (100 buckets + 100 sessions) | Bytes |
|---|---|
| Raw JSON | 62,186 |
| Gzipped | 3,938 |
| **Saved** | **93.7%** |

## Implementation
- `node:zlib` — no new dependencies.
- `gzipSync` is synchronous but trivial at these payload sizes; no streaming complexity.
- Skip compression for bodies < 1 KB (last batch in a sync is often tiny).
- Streaming-write progress callback now reports compressed bytes — that's the byte count actually going over the wire, which is what users care about.
- No protocol break — server change is backward-compat, so v0.7.8 daemons keep working.

## Rollout
1. **Merge & deploy the vibe-cafe PR first** so the server accepts both encodings.
2. Then publish v0.7.9 to npm (manual, per existing flow).

## Test plan
- [x] `node bin/vibe-usage.js sync` against a local vibe-cafe dev server with the matching server change → 415 buckets + 827 sessions ingested, all batches `200 OK`
- [x] Smaller-than-1KB final batch sent uncompressed (verified in stderr progress lines)
- [x] Manual `curl` round-trip on the dev server: gzipped body decodes correctly, raw body still works
- [ ] Manually publish to npm after both PRs land (`npm publish`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)