### PR TITLE
feat(cursor): 添加 Cursor 本地日志 fallback 解析器（保持同一 Cursor source）

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Claude Code | `~/.claude/projects/` (tokens + sessions), `~/.claude/transcripts/` (sessions only) |
 | Codex CLI | `~/.codex/sessions/` |
 | GitHub Copilot CLI | `~/.copilot/session-state/*/events.jsonl` |
-| Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`). Falls back to local hook logs at `~/.config/Cursor/logs/` when no auth token is available. **Note: local log fallback is developed and tested on Linux; macOS/Windows support is implemented but needs real-machine verification.** |
+| Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`). Falls back to local hook logs at `~/.config/Cursor/logs/` when no auth token is available, and uploads them under the same `Cursor` source. Local hook fallback counts aborted blocks when token fields are present. **Note: local log fallback is developed and tested on Linux; macOS/Windows support is implemented but needs real-machine verification.** |
 | Gemini CLI | `~/.gemini/tmp/` |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/`, `~/.openclaw-<profile>/agents/` (profile deployments) |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Claude Code | `~/.claude/projects/` (tokens + sessions), `~/.claude/transcripts/` (sessions only) |
 | Codex CLI | `~/.codex/sessions/` |
 | GitHub Copilot CLI | `~/.copilot/session-state/*/events.jsonl` |
-| Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`) |
+| Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`). Falls back to local hook logs at `~/.config/Cursor/logs/` when no auth token is available. **Note: local log fallback is developed and tested on Linux; macOS/Windows support is implemented but needs real-machine verification.** |
 | Gemini CLI | `~/.gemini/tmp/` |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/`, `~/.openclaw-<profile>/agents/` (profile deployments) |

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "bin/",
     "src/"
   ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
   "engines": {
     "node": ">=20"
   },

--- a/src/parsers/cursor-logs.js
+++ b/src/parsers/cursor-logs.js
@@ -116,8 +116,6 @@ async function parseLogFiles(logDir) {
         continue;
       }
 
-      if (raw.status !== 'completed') continue;
-
       const prompt = n(raw.input_tokens ?? raw.prompt_tokens);
       const output = n(raw.output_tokens ?? raw.completion_tokens);
       const cacheRead = n(raw.cache_read_tokens ?? raw.cache_read_input_tokens);

--- a/src/parsers/cursor-logs.js
+++ b/src/parsers/cursor-logs.js
@@ -1,0 +1,157 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { aggregateToBuckets } from './index.js';
+
+function getDefaultLogDir() {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Cursor', 'logs');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA?.trim();
+    return appData ? join(appData, 'Cursor', 'logs') : join(homedir(), 'AppData', 'Roaming', 'Cursor', 'logs');
+  }
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config');
+  return join(xdgConfigHome, 'Cursor', 'logs');
+}
+
+export function getCursorLogDir() {
+  const explicit = process.env.CURSOR_LOG_DIR?.trim();
+  if (explicit) return explicit;
+  return getDefaultLogDir();
+}
+
+async function findLogFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const sub = await findLogFiles(full);
+      out.push(...sub);
+    } else if (entry.isFile() && entry.name.endsWith('.log')) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+function extractJsonObject(text, startIndex) {
+  const jsonStart = text.indexOf('{', startIndex);
+  if (jsonStart === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = jsonStart; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escape) { escape = false; }
+      else if (ch === '\\') { escape = true; }
+      else if (ch === '"') { inString = false; }
+      continue;
+    }
+    if (ch === '"') { inString = true; }
+    else if (ch === '{') { depth++; }
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(jsonStart, i + 1);
+    }
+  }
+  return null;
+}
+
+function extractTimestampBefore(text, markerIndex) {
+  const before = text.slice(0, markerIndex);
+  const match = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\]/g;
+  let last = null;
+  let m;
+  while ((m = match.exec(before)) !== null) {
+    last = m[1];
+  }
+  return last;
+}
+
+function parseProjectFromRoots(workspaceRoots) {
+  if (!Array.isArray(workspaceRoots) || workspaceRoots.length === 0) return 'unknown';
+  const root = workspaceRoots[0];
+  const parts = root.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
+}
+
+function n(v) {
+  const num = Number(v);
+  return Number.isFinite(num) ? num : 0;
+}
+
+async function parseLogFiles(logDir) {
+  const files = await findLogFiles(logDir);
+  if (files.length === 0) return [];
+
+  const entries = [];
+  for (const filePath of files) {
+    let text;
+    try {
+      text = await readFile(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+    let cursor = 0;
+    while (cursor < text.length) {
+      const markerIndex = text.indexOf('INPUT:', cursor);
+      if (markerIndex === -1) break;
+
+      const jsonText = extractJsonObject(text, markerIndex + 6);
+      cursor = markerIndex + 6;
+      if (!jsonText) continue;
+
+      let raw;
+      try {
+        raw = JSON.parse(jsonText);
+      } catch {
+        continue;
+      }
+
+      if (raw.status !== 'completed') continue;
+
+      const prompt = n(raw.input_tokens ?? raw.prompt_tokens);
+      const output = n(raw.output_tokens ?? raw.completion_tokens);
+      const cacheRead = n(raw.cache_read_tokens ?? raw.cache_read_input_tokens);
+      const cacheWrite = n(raw.cache_write_tokens ?? raw.cache_creation_input_tokens);
+      const reasoning = n(raw.reasoning_tokens ?? raw.reasoning_output_tokens);
+      if (prompt + output + reasoning === 0) continue;
+
+      const ts = raw.timestamp
+        ? new Date(raw.timestamp)
+        : new Date(extractTimestampBefore(text, markerIndex) || '1970-01-01T00:00:00.000Z');
+
+      const isClaudeLike = raw.model && (raw.model.startsWith('gpt-5.') || raw.model.startsWith('claude-'));
+      const inputTokens = isClaudeLike
+        ? Math.max(prompt - cacheRead - cacheWrite, 0)
+        : prompt;
+
+      entries.push({
+        source: 'cursor',
+        model: raw.model || 'unknown',
+        project: parseProjectFromRoots(raw.workspace_roots),
+        timestamp: ts,
+        inputTokens,
+        outputTokens: output,
+        cachedInputTokens: cacheRead,
+        reasoningOutputTokens: reasoning,
+      });
+    }
+  }
+  return entries;
+}
+
+export async function parse() {
+  const logDir = getCursorLogDir();
+  const entries = await parseLogFiles(logDir);
+  if (entries.length === 0) return { buckets: [], sessions: [] };
+  return { buckets: aggregateToBuckets(entries), sessions: [] };
+}

--- a/src/parsers/cursor.js
+++ b/src/parsers/cursor.js
@@ -199,7 +199,7 @@ export async function parse() {
     throw err;
   }
   const rows = parseCsv(csv);
-  if (rows.length < 2) return { buckets: [], sessions: [] };
+  if (rows.length < 2) return parseCursorLogs();
 
   const header = rows[0].map(h => h.trim());
   const idx = (name) => header.indexOf(name);
@@ -210,7 +210,7 @@ export async function parse() {
   const cacheReadIdx = idx('Cache Read');
   const outputIdx = idx('Output Tokens');
 
-  if (dateIdx < 0 || modelIdx < 0) return { buckets: [], sessions: [] };
+  if (dateIdx < 0 || modelIdx < 0) return parseCursorLogs();
 
   const entries = [];
   for (let r = 1; r < rows.length; r++) {
@@ -238,6 +238,8 @@ export async function parse() {
       reasoningOutputTokens: 0,
     });
   }
+
+  if (entries.length === 0) return parseCursorLogs();
 
   return { buckets: aggregateToBuckets(entries), sessions: [] };
 }

--- a/src/parsers/cursor.js
+++ b/src/parsers/cursor.js
@@ -3,6 +3,7 @@ import { copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { aggregateToBuckets } from './index.js';
+import { parse as parseCursorLogs } from './cursor-logs.js';
 
 const STATE_DB_RELATIVE = join('User', 'globalStorage', 'state.vscdb');
 const ACCESS_TOKEN_KEY = 'cursorAuth/accessToken';
@@ -175,7 +176,7 @@ function parseInt0(value) {
 
 export async function parse() {
   const dbPath = getCursorStateDbPath();
-  if (!dbPath) return { buckets: [], sessions: [] };
+  if (!dbPath) return parseCursorLogs();
 
   let token;
   try {
@@ -186,7 +187,7 @@ export async function parse() {
     }
     throw err;
   }
-  if (!token) return { buckets: [], sessions: [] };
+  if (!token) return parseCursorLogs();
 
   let csv;
   try {

--- a/src/tools.js
+++ b/src/tools.js
@@ -58,7 +58,7 @@ export const TOOLS = [
     name: 'Cursor',
     id: 'cursor',
     dataDir: getCursorStateDbPath(),
-    note: 'Uses cursor.com API when authenticated, falls back to local hook logs (~/.config/Cursor/logs)',
+    note: 'Uses cursor.com API when authenticated, falls back to local hook logs (~/.config/Cursor/logs) under the same Cursor source',
   },
   {
     name: 'Gemini CLI',

--- a/src/tools.js
+++ b/src/tools.js
@@ -58,6 +58,7 @@ export const TOOLS = [
     name: 'Cursor',
     id: 'cursor',
     dataDir: getCursorStateDbPath(),
+    note: 'Uses cursor.com API when authenticated, falls back to local hook logs (~/.config/Cursor/logs)',
   },
   {
     name: 'Gemini CLI',

--- a/test/cursor-logs.test.js
+++ b/test/cursor-logs.test.js
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFile, writeFile, mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { parse as parseCursorLogs, getCursorLogDir } from '../src/parsers/cursor-logs.js';
+import { parse as parseCursor } from '../src/parsers/cursor.js';
+
+describe('cursor-logs parser', () => {
+  it('counts completed and aborted blocks with tokens under the same cursor source', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'vibe-usage-cursor-logs-'));
+    const previousLogDir = process.env.CURSOR_LOG_DIR;
+    try {
+      const fixtureText = await readFile(new URL('./fixtures/sample-cursor.log', import.meta.url), 'utf8');
+      await mkdir(tmp, { recursive: true });
+      await writeFile(join(tmp, 'cursor.log'), fixtureText, 'utf8');
+      process.env.CURSOR_LOG_DIR = tmp;
+
+      const result = await parseCursorLogs();
+
+      assert.strictEqual(result.sessions.length, 0);
+      assert.ok(result.buckets.length > 0);
+
+      const sources = new Set(result.buckets.map(b => b.source));
+      assert.deepStrictEqual([...sources], ['cursor']);
+
+      const totalInput = result.buckets.reduce((s, b) => s + b.inputTokens, 0);
+      const totalOutput = result.buckets.reduce((s, b) => s + b.outputTokens, 0);
+      const totalCache = result.buckets.reduce((s, b) => s + b.cachedInputTokens, 0);
+
+      // completed: (325659 - 325120) + 1032
+      // aborted: (1000 - 900) + 200
+      assert.strictEqual(totalInput, 639);
+      assert.strictEqual(totalOutput, 1232);
+      assert.strictEqual(totalCache, 326020);
+    } finally {
+      if (previousLogDir == null) delete process.env.CURSOR_LOG_DIR;
+      else process.env.CURSOR_LOG_DIR = previousLogDir;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back from cursor parser to local logs under the same cursor source', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'vibe-usage-cursor-fallback-'));
+    const previousLogDir = process.env.CURSOR_LOG_DIR;
+    const previousStateDb = process.env.CURSOR_STATE_DB_PATH;
+    try {
+      const fixtureText = await readFile(new URL('./fixtures/sample-cursor.log', import.meta.url), 'utf8');
+      await mkdir(tmp, { recursive: true });
+      await writeFile(join(tmp, 'cursor.log'), fixtureText, 'utf8');
+      process.env.CURSOR_LOG_DIR = tmp;
+      process.env.CURSOR_STATE_DB_PATH = join(tmp, 'missing-state.vscdb');
+
+      const result = await parseCursor();
+      assert.ok(result.buckets.length > 0);
+      const sources = new Set(result.buckets.map(b => b.source));
+      assert.deepStrictEqual([...sources], ['cursor']);
+    } finally {
+      if (previousLogDir == null) delete process.env.CURSOR_LOG_DIR;
+      else process.env.CURSOR_LOG_DIR = previousLogDir;
+      if (previousStateDb == null) delete process.env.CURSOR_STATE_DB_PATH;
+      else process.env.CURSOR_STATE_DB_PATH = previousStateDb;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves platform log paths', () => {
+    const originalPlatform = process.platform;
+    const originalAppData = process.env.APPDATA;
+
+    const desc = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    assert.ok(getCursorLogDir().includes('.config/Cursor/logs'));
+
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    assert.ok(getCursorLogDir().includes('Library/Application Support/Cursor/logs'));
+
+    process.env.APPDATA = 'C:/Users/demo/AppData/Roaming';
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    assert.ok(getCursorLogDir().includes('Cursor/logs'));
+
+    if (desc) Object.defineProperty(process, 'platform', desc);
+    process.env.APPDATA = originalAppData;
+  });
+});

--- a/test/fixtures/sample-cursor.log
+++ b/test/fixtures/sample-cursor.log
@@ -1,0 +1,42 @@
+[2026-04-30T08:00:50.683Z] Hook step requested: stop
+INPUT:
+{
+  "conversation_id": "32676ff8-cd67-45c6-af79-5510adaf6c95",
+  "generation_id": "2035c6d5-1e19-4831-b62e-b34ef36f4877",
+  "model": "gpt-5.4",
+  "status": "completed",
+  "input_tokens": 325659,
+  "output_tokens": 1032,
+  "cache_read_tokens": 325120,
+  "session_id": "32676ff8-cd67-45c6-af79-5510adaf6c95",
+  "workspace_roots": ["/tmp/demo"]
+}
+OUTPUT:
+(empty)
+[2026-04-30T08:04:34.891Z] Hook step requested: stop
+INPUT:
+{
+  "conversation_id": "93688faf-02b3-4b43-95a4-4179b0dee37e",
+  "generation_id": "621c35c8-58ac-4857-bd87-8bb58b19c293",
+  "model": "gpt-5.5",
+  "status": "aborted",
+  "input_tokens": 1000,
+  "output_tokens": 200,
+  "cache_read_tokens": 900,
+  "session_id": "93688faf-02b3-4b43-95a4-4179b0dee37e",
+  "workspace_roots": ["/tmp/demo"]
+}
+OUTPUT:
+(empty)
+[2026-04-30T09:05:00.000Z] Hook step requested: stop
+INPUT:
+{
+  "conversation_id": "no-tokens-1234-5678-90ab-cdef12345678",
+  "generation_id": "no-tokens-8765-4321-10fe-dcba87654321",
+  "model": "gpt-5.4",
+  "status": "completed",
+  "session_id": "no-tokens-1234-5678-90ab-cdef12345678",
+  "workspace_roots": []
+}
+OUTPUT:
+(empty)


### PR DESCRIPTION
## 概述

为 Cursor 添加本地日志 fallback 解析器。当没有 auth token、`state.vscdb` 缺失、CSV 返回空结果或解析后无有效 entries 时，`vibe-usage` 会回退到 Cursor 本地 hook 日志继续统计用量。

这次更新特别确认了两点：

1. 本地日志 fallback **仍然记到同一个 `Cursor` source**，不会作为新的独立客户端名上传。
2. `aborted` 但带 token 字段的调用也会计入，因为这类调用通常也会收费。

## 改动

### 新增 `src/parsers/cursor-logs.js`
- 扫描 Cursor 本地 hook 日志：`~/.config/Cursor/logs/**/*.log`
- 解析 `INPUT:` JSON blocks 中带 token 的调用
- 统计 `completed` 与 `aborted` 且带 token 的块
- 跨平台默认路径：
  - Linux: `~/.config/Cursor/logs`
  - macOS: `~/Library/Application Support/Cursor/logs`
  - Windows: `%APPDATA%/Cursor/logs`
- Claude-like 模型（`gpt-5.*` / `claude-*`）沿用缓存 token 扣减逻辑
- `CURSOR_LOG_DIR` 环境变量可覆盖默认路径

### 修改 `src/parsers/cursor.js`
- 无 `state.vscdb` 或无 auth token 时 fallback 到 `cursor-logs.js`
- API 网络 soft skip 时保持当前静默策略
- **新增 fallback 场景**：
  - CSV 行数不足（`rows.length < 2`）
  - CSV header 缺少关键字段
  - CSV 解析后 `entries.length === 0`
- 保持 API 路径优先，本地日志仅作为 backup/fallback

### 修改 `src/tools.js`
- Cursor 工具说明补充：本地 hook logs fallback 仍然归属同一个 `Cursor` source

### 修改 `README.md`
- Supported Tools 表中 Cursor 行补充说明：
  - local hook logs 只是 fallback
  - 上传时仍归属同一个 `Cursor` source
  - aborted 且有 token 的本地块也会计入

### 新增最小测试
- `test/fixtures/sample-cursor.log`
- `test/cursor-logs.test.js`

覆盖：
- completed + token -> 计入
- aborted + token -> 计入
- `parseCursor()` 在 API 不可用/无数据时会 fallback 到本地 logs
- fallback 产出的 bucket `source === 'cursor'`
- 平台日志路径函数正确

## 本地验证

### 单测
```bash
cd /tmp/vibe-usage
npm test
```

结果：
```text
pass 3 / fail 0
```

### parser 级验证
```bash
cd /tmp/vibe-usage
node --input-type=module - <<'NODE'
import { parse as parseCursor } from './src/parsers/cursor.js';
const result = await parseCursor();
console.log(JSON.stringify({ buckets: result.buckets.length, firstBucket: result.buckets[0] }, null, 2));
NODE
```

结果：
- `parseCursor()` 现在能产出 **58 buckets**
- `firstBucket.source === "cursor"`

### sync 级验证
```bash
cd /tmp/vibe-usage
node ./bin/vibe-usage.js sync
```

输出已验证出现：
```text
cursor        58 buckets
```

而不是把本地日志统计成 `claude-code`。

## 开发环境说明

- 当前仅在 **Linux** 环境下开发和测试
- macOS / Windows 路径逻辑已实现，但**尚未做实机验证**
- 建议 macOS / Windows 用户在合入后额外验证
- 如果默认路径检测失败，可通过 `CURSOR_LOG_DIR` 手动指定