### PR TITLE
修复 Codex forked session 重复统计 token_count

### DIFF
--- a/src/parsers/codex.js
+++ b/src/parsers/codex.js
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { aggregateToBuckets, extractSessions } from './index.js';
 
 const SESSIONS_DIR = join(homedir(), '.codex', 'sessions');
+const FORK_REPLAY_WINDOW_MS = 5_000;
 
 /**
  * Recursively find all .jsonl files under a directory.
@@ -27,12 +28,12 @@ function findJsonlFiles(dir) {
   return results;
 }
 
-export async function parse() {
-  if (!existsSync(SESSIONS_DIR)) return { buckets: [], sessions: [] };
+export async function parse({ sessionsDir = SESSIONS_DIR } = {}) {
+  if (!existsSync(sessionsDir)) return { buckets: [], sessions: [] };
 
   const entries = [];
   const sessionEvents = [];
-  const files = findJsonlFiles(SESSIONS_DIR);
+  const files = findJsonlFiles(sessionsDir);
   if (files.length === 0) return { buckets: [], sessions: [] };
   for (const filePath of files) {
 
@@ -43,15 +44,22 @@ export async function parse() {
       continue;
     }
 
-    // Extract project name and model from session_meta line
+    // Extract project name, model, and fork metadata from session_meta lines.
     let sessionProject = 'unknown';
     let sessionModel = 'unknown';
+    let forkReplayUntil = null;
     for (const line of content.split('\n')) {
       if (!line.trim()) continue;
       try {
         const obj = JSON.parse(line);
         if (obj.type === 'session_meta' && obj.payload) {
           const meta = obj.payload;
+          if (meta.forked_from_id && obj.timestamp) {
+            const forkStart = new Date(obj.timestamp);
+            if (!isNaN(forkStart.getTime())) {
+              forkReplayUntil = new Date(forkStart.getTime() + FORK_REPLAY_WINDOW_MS);
+            }
+          }
           if (meta.cwd) {
             sessionProject = meta.cwd.split('/').pop() || 'unknown';
           }
@@ -75,14 +83,16 @@ export async function parse() {
         if (obj.timestamp) {
           const evTs = new Date(obj.timestamp);
           if (!isNaN(evTs.getTime())) {
-            const isUserTurn = obj.type === 'turn_context' || obj.type === 'session_meta';
-            sessionEvents.push({
-              sessionId: filePath,
-              source: 'codex',
-              project: sessionProject,
-              timestamp: evTs,
-              role: isUserTurn ? 'user' : 'assistant',
-            });
+            if (!forkReplayUntil || evTs > forkReplayUntil) {
+              const isUserTurn = obj.type === 'turn_context' || obj.type === 'session_meta';
+              sessionEvents.push({
+                sessionId: filePath,
+                source: 'codex',
+                project: sessionProject,
+                timestamp: evTs,
+                role: isUserTurn ? 'user' : 'assistant',
+              });
+            }
           }
         }
 
@@ -103,6 +113,7 @@ export async function parse() {
 
         const timestamp = obj.timestamp ? new Date(obj.timestamp) : null;
         if (!timestamp || isNaN(timestamp.getTime())) continue;
+        if (forkReplayUntil && timestamp <= forkReplayUntil) continue;
 
         // Prefer incremental per-request usage; compute delta from cumulative total as fallback
         let usage = info.last_token_usage;

--- a/test/codex.test.js
+++ b/test/codex.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { parse } from '../src/parsers/codex.js';
+
+function writeJsonl(filePath, rows) {
+  writeFileSync(filePath, rows.map(row => JSON.stringify(row)).join('\n') + '\n');
+}
+
+test('codex parser skips fork replay token counts', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-codex-'));
+  try {
+    const sessionsDir = join(root, 'sessions');
+    mkdirSync(sessionsDir, { recursive: true });
+    const forkedSession = join(sessionsDir, 'rollout-forked.jsonl');
+
+    writeJsonl(forkedSession, [
+      {
+        type: 'session_meta',
+        timestamp: '2026-05-15T13:49:28.000Z',
+        payload: {
+          id: 'forked',
+          forked_from_id: 'original',
+          cwd: '/tmp/project',
+        },
+      },
+      {
+        type: 'turn_context',
+        timestamp: '2026-05-15T13:49:28.100Z',
+        payload: { model: 'gpt-5.5' },
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-05-15T13:49:28.200Z',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 1_000_000,
+              cached_input_tokens: 900_000,
+              output_tokens: 10_000,
+              reasoning_output_tokens: 2_000,
+            },
+          },
+        },
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-05-15T13:49:35.000Z',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 1_000,
+              cached_input_tokens: 100,
+              output_tokens: 200,
+              reasoning_output_tokens: 50,
+            },
+          },
+        },
+      },
+    ]);
+
+    const { buckets } = await parse({ sessionsDir });
+
+    assert.equal(buckets.length, 1);
+    assert.equal(buckets[0].inputTokens, 900);
+    assert.equal(buckets[0].cachedInputTokens, 100);
+    assert.equal(buckets[0].outputTokens, 150);
+    assert.equal(buckets[0].reasoningOutputTokens, 50);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
﻿## Summary

这个 PR 修复 Codex forked session 导致历史 `token_count` 被重复统计的问题。

- 在 Codex parser 中识别 forked session
- 跳过 fork 创建瞬间复制过来的历史 replay `token_count`
- 保持普通 Codex session 的统计逻辑不变
- 新增一个 `node:test` 回归测试，验证 replay 会被跳过，fork 后真实新增 usage 仍会被统计

## 问题原因

Codex 在 fork 一个对话时，会把原 session 的历史事件复制到新的 JSONL 文件里。这些历史事件里也包含 `event_msg` / `token_count`。

当前 parser 会把这些复制过来的历史 `token_count` 当成新的 usage 统计，导致 fork 时间点出现异常高的 token 和 cost spike。

## 修复方式

当 session 的 `session_meta.payload.forked_from_id` 存在时，将其视为 forked session，并跳过 fork 开始后短时间窗口内的 replay events。

这样可以避免原对话的历史 usage 在新 session 中被重复计算，同时仍然保留 fork 之后真实新增的 usage。

## Validation

- `node --test`
- 使用本地真实的 forked Codex session 验证：异常 replay bucket 被移除，fork 后真实新增 usage 仍保留
