### PR TITLE
feat: add TRAE IDE parser

### DIFF
--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -17,6 +17,7 @@ import { parse as parseHermes } from './hermes.js';
 import { parse as parseKiro } from './kiro.js';
 import { parse as parsePiCodingAgent } from './pi-coding-agent.js';
 import { parse as parseZcode } from './zcode.js';
+import { parse as parseTrae } from './trae.js';
 
 export const parsers = {
   'claude-code': parseClaudeCode,
@@ -37,6 +38,7 @@ export const parsers = {
   'kiro': parseKiro,
   'pi-coding-agent': parsePiCodingAgent,
   'zcode': parseZcode,
+  'trae': parseTrae,
 };
 
 

--- a/src/parsers/trae.js
+++ b/src/parsers/trae.js
@@ -1,0 +1,181 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { aggregateToBuckets, extractSessions } from './index.js';
+
+const TRAE_HOSTS = ['Trae CN', 'Trae', 'TRAE SOLO CN'];
+
+function getTraeUserDirs() {
+  const out = [];
+  if (process.platform === 'darwin') {
+    const base = join(homedir(), 'Library', 'Application Support');
+    for (const h of TRAE_HOSTS) out.push(join(base, h, 'User'));
+  } else if (process.platform === 'win32') {
+    const appData = process.env.APPDATA?.trim() || join(homedir(), 'AppData', 'Roaming');
+    for (const h of TRAE_HOSTS) out.push(join(appData, h, 'User'));
+  } else {
+    const xdg = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config');
+    for (const h of TRAE_HOSTS) out.push(join(xdg, h, 'User'));
+  }
+  return out.filter(existsSync);
+}
+
+function findChatSessionFiles() {
+  const files = [];
+  for (const userDir of getTraeUserDirs()) {
+    const wsDir = join(userDir, 'workspaceStorage');
+    if (existsSync(wsDir)) {
+      for (const ws of readdirSync(wsDir, { withFileTypes: true })) {
+        if (!ws.isDirectory()) continue;
+        const csDir = join(wsDir, ws.name, 'chatSessions');
+        if (!existsSync(csDir)) continue;
+        for (const f of readdirSync(csDir)) {
+          if (f.endsWith('.jsonl')) files.push({ path: join(csDir, f), project: readProjectName(join(wsDir, ws.name)) });
+        }
+      }
+    }
+    const ewDir = join(userDir, 'globalStorage', 'emptyWindowChatSessions');
+    if (existsSync(ewDir)) {
+      for (const f of readdirSync(ewDir)) {
+        if (f.endsWith('.jsonl')) files.push({ path: join(ewDir, f), project: 'unknown' });
+      }
+    }
+  }
+  return files;
+}
+
+function readProjectName(wsDir) {
+  try {
+    const meta = JSON.parse(readFileSync(join(wsDir, 'workspace.json'), 'utf-8'));
+    const uri = meta.folder || meta.workspace?.folders?.[0]?.uri || '';
+    const match = String(uri).match(/file:\/\/(.+)/);
+    if (match) {
+      const parts = match[1].replace(/\/$/, '').split('/');
+      return parts[parts.length - 1] || 'unknown';
+    }
+  } catch {}
+  return 'unknown';
+}
+
+function extractModelFromDetails(details) {
+  const name = details.split('•')[0].trim();
+  if (!name) return 'unknown';
+  return name.toLowerCase().replace(/\s+/g, '-');
+}
+
+function parseSessionFile(filePath, project) {
+  const entries = [];
+  const sessionEvents = [];
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch {
+    return { entries, sessionEvents };
+  }
+
+  const lines = raw.split('\n').filter(l => l.trim());
+  if (lines.length === 0) return { entries, sessionEvents };
+
+  let sessionId = '';
+  let creationDate = null;
+  let pendingMetadata = null;
+  let pendingModel = 'unknown';
+
+  for (const line of lines) {
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const kind = obj.kind;
+    const v = obj.v;
+
+    if (kind === 0 && v && typeof v === 'object') {
+      sessionId = v.sessionId || '';
+      creationDate = v.creationDate || null;
+      continue;
+    }
+
+    if (kind !== 1 || !v || typeof v !== 'object') continue;
+
+    if (v.metadata && typeof v.metadata === 'object') {
+      const meta = v.metadata;
+      const promptTokens = Number(meta.promptTokens) || 0;
+      const outputTokens = Number(meta.outputTokens) || 0;
+      if (promptTokens > 0 || outputTokens > 0) {
+        pendingMetadata = { promptTokens, outputTokens };
+        if (v.resolvedModel) {
+          pendingModel = String(v.resolvedModel);
+        } else if (v.details) {
+          pendingModel = extractModelFromDetails(String(v.details));
+        }
+      }
+      continue;
+    }
+
+    if (v.completedAt && pendingMetadata) {
+      const ts = new Date(Number(v.completedAt));
+      if (!isNaN(ts.getTime())) {
+        entries.push({
+          source: 'trae',
+          model: pendingModel,
+          project,
+          timestamp: ts,
+          inputTokens: pendingMetadata.promptTokens,
+          outputTokens: pendingMetadata.outputTokens,
+          cachedInputTokens: 0,
+          reasoningOutputTokens: 0,
+        });
+        if (sessionId) {
+          sessionEvents.push({
+            sessionId,
+            source: 'trae',
+            project,
+            timestamp: ts,
+            role: 'assistant',
+          });
+        }
+      }
+      pendingMetadata = null;
+      continue;
+    }
+  }
+
+  if (pendingMetadata) {
+    let ts = creationDate ? new Date(Number(creationDate)) : null;
+    if (!ts || isNaN(ts.getTime())) {
+      try { ts = statSync(filePath).mtime; } catch { ts = new Date(); }
+    }
+    entries.push({
+      source: 'trae',
+      model: pendingModel,
+      project,
+      timestamp: ts,
+      inputTokens: pendingMetadata.promptTokens,
+      outputTokens: pendingMetadata.outputTokens,
+      cachedInputTokens: 0,
+      reasoningOutputTokens: 0,
+    });
+  }
+
+  return { entries, sessionEvents };
+}
+
+export async function parse() {
+  const files = findChatSessionFiles();
+  const allEntries = [];
+  const allEvents = [];
+
+  for (const { path, project } of files) {
+    const { entries, sessionEvents } = parseSessionFile(path, project);
+    allEntries.push(...entries);
+    allEvents.push(...sessionEvents);
+  }
+
+  return {
+    buckets: aggregateToBuckets(allEntries),
+    sessions: extractSessions(allEvents),
+  };
+}

--- a/src/tools.js
+++ b/src/tools.js
@@ -104,6 +104,39 @@ function findCodexDataDirs() {
   ].filter(existsSync);
 }
 
+// TRAE IDE (VS Code fork by ByteDance) stores AI chat sessions under
+// workspaceStorage/<ws>/chatSessions/*.jsonl and globalStorage/emptyWindowChatSessions/*.jsonl
+function findTraeChatSessionDirs() {
+  const hosts = ['Trae CN', 'Trae', 'TRAE SOLO CN'];
+  const dirs = [];
+  if (process.platform === 'darwin') {
+    const base = join(homedir(), 'Library', 'Application Support');
+    for (const h of hosts) {
+      const wsDir = join(base, h, 'User', 'workspaceStorage');
+      if (existsSync(wsDir)) dirs.push(wsDir);
+      const ewDir = join(base, h, 'User', 'globalStorage', 'emptyWindowChatSessions');
+      if (existsSync(ewDir)) dirs.push(ewDir);
+    }
+  } else if (process.platform === 'win32') {
+    const appData = process.env.APPDATA?.trim() || join(homedir(), 'AppData', 'Roaming');
+    for (const h of hosts) {
+      const wsDir = join(appData, h, 'User', 'workspaceStorage');
+      if (existsSync(wsDir)) dirs.push(wsDir);
+      const ewDir = join(appData, h, 'User', 'globalStorage', 'emptyWindowChatSessions');
+      if (existsSync(ewDir)) dirs.push(ewDir);
+    }
+  } else {
+    const xdg = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config');
+    for (const h of hosts) {
+      const wsDir = join(xdg, h, 'User', 'workspaceStorage');
+      if (existsSync(wsDir)) dirs.push(wsDir);
+      const ewDir = join(xdg, h, 'User', 'globalStorage', 'emptyWindowChatSessions');
+      if (existsSync(ewDir)) dirs.push(ewDir);
+    }
+  }
+  return dirs;
+}
+
 export const TOOLS = [
   {
     name: 'Antigravity',
@@ -199,6 +232,12 @@ export const TOOLS = [
     name: 'ZCode',
     id: 'zcode',
     dataDir: join(homedir(), '.zcode', 'cli', 'db', 'db.sqlite'),
+  },
+  {
+    name: 'TRAE',
+    id: 'trae',
+    dataDir: join(homedir(), 'Library', 'Application Support', 'Trae CN', 'User', 'workspaceStorage'),
+    detectDataDirs: findTraeChatSessionDirs,
   },
 ];
 


### PR DESCRIPTION
## What

Add support for **TRAE IDE** (ByteDance's VS Code fork) — parses AI chat token usage from local JSONL session logs.

## Why

TRAE is a popular AI coding IDE (especially in China), but vibe-usage currently has no parser for it. TRAE users can't track their token spend on vibecafe.ai.

## How

TRAE stores chat sessions as JSONL under:
- `workspaceStorage/<ws>/chatSessions/*.jsonl` (per-project)
- `globalStorage/emptyWindowChatSessions/*.jsonl` (empty window)

The parser scans all TRAE host variants (`Trae CN`, `Trae`, `TRAE SOLO CN`) and parses the JSONL state machine:
- `kind=0`: session metadata (`sessionId`, `creationDate`)
- `kind=1` + `metadata`: captures `promptTokens` / `outputTokens` / model
- `kind=1` + `completedAt`: emits entry with timestamp

Cross-platform path resolution (macOS / Windows / Linux).

## Files

- `src/parsers/trae.js` — new parser (181 lines)
- `src/parsers/index.js` — register `trae` parser
- `src/tools.js` — add `findTraeChatSessionDirs()` + TRAE entry in `TOOLS[]`

## Test

Parsed real local TRAE usage data:
```
buckets: 428
sessions: 218
sample bucket: {"source":"trae","model":"claude-sonnet-4.6","project":"unknown","bucketStart":"2026-04-28T19:00:00.000Z","inputTokens":101032,"outputTokens":663,"totalTokens":101695}
```

## Note

Server-side source whitelist also needs to accept `trae` — currently the ingest API drops all `trae` buckets with `unknownSources: ["trae"]`. This PR adds the client-side parser; server-side allowlist update is required for the data to actually land.