### PR TITLE
feat: add CraftAgent usage parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ vibe-usage/
 │   ├── index.js               # Command router (init, sync, daemon, reset, skill, status, config)
 │   ├── parsers/               # One parser per tool, all export async parse() → { buckets, sessions }
 │   │   ├── index.js           # Parser registry, aggregateToBuckets(), extractSessions()
+│   │   ├── pi-session-jsonl.js # Shared JSONL reader for Pi-compatible session logs
 │   │   ├── claude-code.js
 │   │   ├── codex.js
+│   │   ├── craft-agent.js     # CraftAgent ~/.craft-agent/workspaces/*/sessions/*/.pi-sessions/*.jsonl
 │   │   ├── copilot-cli.js
 │   │   ├── sqlite.js          # queryDbJson() — node:sqlite (Node ≥22.5), falls back to sqlite3 CLI
 │   │   ├── cursor.js          # SQLite (read auth token) + cursor.com CSV export
@@ -89,6 +91,11 @@ Parser pattern:
 - Extract user/assistant timing events → `extractSessions(events)`
 - Handle missing/corrupt files gracefully (try/catch, skip bad lines)
 
+Pi-compatible JSONL parsers (`pi-coding-agent.js`, `craft-agent.js`):
+- Use `parsePiSessionJsonl()` from `src/parsers/pi-session-jsonl.js` instead of duplicating recursive file walking and message/usage extraction.
+- The helper only counts assistant messages with `message.usage`; user/toolResult messages are timing events only.
+- Project comes from the session header `cwd` when present; parser-specific path heuristics are only fallbacks.
+
 SQLite-backed parsers (cursor, opencode, kiro, hermes):
 - Use `queryDbJson(dbPath, sql)` from `src/parsers/sqlite.js` — never shell out to `sqlite3` directly. It prefers Node's built-in `node:sqlite` (`DatabaseSync`, opened read-only; Node ≥ 22.5, works on Windows with no extra binary) and falls back to the `sqlite3` CLI on older Node.
 - Rows come back as plain objects (`{ column: value }`), same shape as `sqlite3 -json` — INTEGER → number, TEXT → string, JSON via `json_extract` → string.
@@ -112,6 +119,8 @@ Codex archived sessions (`codex.js`, `tools.js`):
 ## Development & Testing
 
 ```bash
+npm test
+
 # Dev mode (separate config, custom API URL)
 VIBE_USAGE_DEV=1 VIBE_USAGE_API_URL=http://localhost:3000 node ./bin/vibe-usage.js init
 VIBE_USAGE_DEV=1 node ./bin/vibe-usage.js sync

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 |------|---------------|
 | Claude Code | `~/.claude/projects/` (tokens + sessions), `~/.claude/transcripts/` (sessions only); also scans `$CLAUDE_CONFIG_DIR` when set (deduped), so relocated configs and GUI/CLI env mismatches are both covered |
 | Codex CLI | `~/.codex/sessions/` and `~/.codex/archived_sessions/` |
+| CraftAgent | `~/.craft-agent/workspaces/*/sessions/*/.pi-sessions/*.jsonl` |
 | GitHub Copilot CLI | `~/.copilot/session-state/*/events.jsonl` |
 | Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`); cloud data is stamped with a fixed `cursor-cloud` hostname so multi-machine setups don't double-count |
 | Gemini CLI | `~/.gemini/tmp/<project_hash>/chats/session-*.jsonl` (current line-delimited format) and legacy `session-*.json`; recurses into nested subagent sessions |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "vibe-usage": "bin/vibe-usage.js"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "files": [
     "bin/",
     "src/"

--- a/src/parsers/craft-agent.js
+++ b/src/parsers/craft-agent.js
@@ -29,7 +29,8 @@ function isPiSessionFile(filePath) {
 function projectFromCraftPath(filePath) {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const sessionsIndex = parts.lastIndexOf('sessions');
-  if (sessionsIndex > 0 && parts[sessionsIndex - 1]) return parts[sessionsIndex - 1];
+  const sessionName = parts[sessionsIndex + 1];
+  if (sessionsIndex >= 0 && sessionName) return sessionName;
   return 'unknown';
 }
 

--- a/src/parsers/craft-agent.js
+++ b/src/parsers/craft-agent.js
@@ -1,0 +1,44 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { parsePiSessionJsonl } from './pi-session-jsonl.js';
+
+/**
+ * CraftAgent parser.
+ * Reads assistant usage from CraftAgent's per-session Pi-compatible JSONL logs.
+ *
+ * Session file layout:
+ *   ~/.craft-agent/workspaces/<workspace>/sessions/<session>/.pi-sessions/*.jsonl
+ *
+ * Assistant messages carry per-message token usage:
+ *   message.usage = { input, output, cacheRead, cacheWrite, totalTokens, cost }
+ *
+ * The current bucket schema tracks tokens only. Cost is intentionally ignored here
+ * until the shared ingest model grows a cost field.
+ */
+
+function getSessionsRoot() {
+  const envDir = process.env.CRAFT_AGENT_DIR || process.env.CRAFTAGENT_DIR;
+  if (envDir) return join(envDir, 'workspaces');
+  return join(homedir(), '.craft-agent', 'workspaces');
+}
+
+function isPiSessionFile(filePath) {
+  return filePath.split(/[\\/]/).includes('.pi-sessions');
+}
+
+function projectFromCraftPath(filePath) {
+  const parts = filePath.replace(/\\/g, '/').split('/');
+  const sessionsIndex = parts.lastIndexOf('sessions');
+  if (sessionsIndex > 0 && parts[sessionsIndex - 1]) return parts[sessionsIndex - 1];
+  return 'unknown';
+}
+
+export async function parse() {
+  const sessionsDir = getSessionsRoot();
+  return parsePiSessionJsonl({
+    source: 'craft-agent',
+    sessionsDir,
+    includeFile: isPiSessionFile,
+    projectFromPath: projectFromCraftPath,
+  });
+}

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -3,6 +3,7 @@ import { parse as parseClaudeCode } from './claude-code.js';
 import { parse as parseCline } from './cline.js';
 import { parse as parseCodex } from './codex.js';
 import { parse as parseCopilotCli } from './copilot-cli.js';
+import { parse as parseCraftAgent } from './craft-agent.js';
 import { parse as parseCursor } from './cursor.js';
 import { parse as parseRooCode } from './roo-code.js';
 import { parse as parseGeminiCli } from './gemini-cli.js';
@@ -23,6 +24,7 @@ export const parsers = {
   'cline': parseCline,
   'codex': parseCodex,
   'copilot-cli': parseCopilotCli,
+  'craft-agent': parseCraftAgent,
   'cursor': parseCursor,
   'roo-code': parseRooCode,
   'gemini-cli': parseGeminiCli,

--- a/src/parsers/pi-coding-agent.js
+++ b/src/parsers/pi-coding-agent.js
@@ -1,7 +1,6 @@
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { aggregateToBuckets, extractSessions } from './index.js';
+import { extractProjectFromFirstDir, parsePiSessionJsonl } from './pi-session-jsonl.js';
 
 /**
  * pi-coding-agent parser.
@@ -9,11 +8,6 @@ import { aggregateToBuckets, extractSessions } from './index.js';
  *
  * Session file layout:
  *   sessions/<encoded-cwd>/{timestamp}_{sessionId}.jsonl
- *
- * Each JSONL line is a session entry:
- *   - type "session": header with id, cwd, version
- *   - type "message": contains message object with role, usage, model, timestamp
- *   - type "model_change", "compaction", etc.: metadata (ignored for usage)
  *
  * Assistant messages carry per-message token usage:
  *   message.usage = { input, output, cacheRead, cacheWrite, totalTokens }
@@ -25,120 +19,11 @@ function getSessionsDir() {
   return join(homedir(), '.pi', 'agent', 'sessions');
 }
 
-function findJsonlFiles(dir) {
-  const results = [];
-  if (!existsSync(dir)) return results;
-  try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        results.push(...findJsonlFiles(fullPath));
-      } else if (entry.name.endsWith('.jsonl')) {
-        results.push(fullPath);
-      }
-    }
-  } catch {
-    // ignore unreadable directories
-  }
-  return results;
-}
-
-function extractProjectFromCwd(cwd) {
-  if (!cwd) return 'unknown';
-  const parts = cwd.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
-}
-
-function extractProjectFromDir(filePath, sessionsDir) {
-  const relative = filePath.slice(sessionsDir.length + 1);
-  const firstSeg = relative.split('/')[0] || relative.split('\\')[0];
-  if (!firstSeg) return 'unknown';
-  const parts = firstSeg.split('-').filter(Boolean);
-  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
-}
-
 export async function parse() {
   const sessionsDir = getSessionsDir();
-  const entries = [];
-  const sessionEvents = [];
-  const seenEntryIds = new Set();
-
-  const sessionFiles = findJsonlFiles(sessionsDir);
-
-  for (const filePath of sessionFiles) {
-    let content;
-    try {
-      content = readFileSync(filePath, 'utf-8');
-    } catch {
-      continue;
-    }
-
-    let sessionId = basename(filePath, '.jsonl');
-    let project = extractProjectFromDir(filePath, sessionsDir);
-
-    for (const line of content.split('\n')) {
-      if (!line.trim()) continue;
-
-      let obj;
-      try {
-        obj = JSON.parse(line);
-      } catch {
-        continue;
-      }
-
-      if (obj.type === 'session') {
-        if (obj.id) sessionId = obj.id;
-        if (obj.cwd) project = extractProjectFromCwd(obj.cwd);
-        continue;
-      }
-
-      if (obj.type !== 'message') continue;
-
-      const msg = obj.message;
-      if (!msg) continue;
-
-      let ts;
-      if (obj.timestamp) {
-        ts = new Date(obj.timestamp);
-      } else if (msg.timestamp) {
-        ts = new Date(msg.timestamp);
-      }
-      if (!ts || isNaN(ts.getTime())) continue;
-
-      if (msg.role === 'user' || msg.role === 'assistant' || msg.role === 'toolResult') {
-        sessionEvents.push({
-          sessionId,
-          source: 'pi-coding-agent',
-          project,
-          timestamp: ts,
-          role: msg.role === 'user' ? 'user' : 'assistant',
-        });
-      }
-
-      if (msg.role !== 'assistant') continue;
-      if (!msg.usage) continue;
-
-      const usage = msg.usage;
-      if (usage.input == null && usage.output == null) continue;
-
-      const entryId = obj.id;
-      if (entryId) {
-        if (seenEntryIds.has(entryId)) continue;
-        seenEntryIds.add(entryId);
-      }
-
-      entries.push({
-        source: 'pi-coding-agent',
-        model: msg.model || 'unknown',
-        project,
-        timestamp: ts,
-        inputTokens: usage.input || 0,
-        outputTokens: usage.output || 0,
-        cachedInputTokens: usage.cacheRead || 0,
-        reasoningOutputTokens: 0,
-      });
-    }
-  }
-
-  return { buckets: aggregateToBuckets(entries), sessions: extractSessions(sessionEvents) };
+  return parsePiSessionJsonl({
+    source: 'pi-coding-agent',
+    sessionsDir,
+    projectFromPath: extractProjectFromFirstDir,
+  });
 }

--- a/src/parsers/pi-session-jsonl.js
+++ b/src/parsers/pi-session-jsonl.js
@@ -1,0 +1,116 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, sep } from 'node:path';
+import { aggregateToBuckets, extractSessions } from './index.js';
+
+function findJsonlFiles(dir, includeFile = () => true) {
+  const results = [];
+  if (!existsSync(dir)) return results;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = `${dir}${sep}${entry.name}`;
+      if (entry.isDirectory()) {
+        results.push(...findJsonlFiles(fullPath, includeFile));
+      } else if (entry.name.endsWith('.jsonl') && includeFile(fullPath)) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // Ignore unreadable directories. A parser should never break the whole sync.
+  }
+  return results;
+}
+
+function numberOrZero(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function extractProjectFromCwd(cwd) {
+  if (!cwd) return 'unknown';
+  const parts = cwd.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
+}
+
+export function extractProjectFromFirstDir(filePath, sessionsDir) {
+  const relative = filePath.slice(sessionsDir.length + 1);
+  const firstSeg = relative.split(/[\\/]/)[0];
+  if (!firstSeg) return 'unknown';
+  const parts = firstSeg.split('-').filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
+}
+
+export function parsePiSessionJsonl({ source, sessionsDir, includeFile, projectFromPath }) {
+  const entries = [];
+  const sessionEvents = [];
+  const seenEntryIds = new Set();
+  const sessionFiles = findJsonlFiles(sessionsDir, includeFile);
+
+  for (const filePath of sessionFiles) {
+    let content;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let sessionId = basename(filePath, '.jsonl');
+    let project = projectFromPath?.(filePath, sessionsDir) || extractProjectFromFirstDir(filePath, sessionsDir);
+
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (obj.type === 'session') {
+        if (obj.id) sessionId = obj.id;
+        if (obj.cwd) project = extractProjectFromCwd(obj.cwd);
+        continue;
+      }
+
+      if (obj.type !== 'message' || !obj.message) continue;
+
+      const msg = obj.message;
+      const ts = new Date(obj.timestamp || msg.timestamp || 0);
+      if (Number.isNaN(ts.getTime())) continue;
+
+      if (msg.role === 'user' || msg.role === 'assistant' || msg.role === 'toolResult') {
+        sessionEvents.push({
+          sessionId,
+          source,
+          project,
+          timestamp: ts,
+          role: msg.role === 'user' ? 'user' : 'assistant',
+        });
+      }
+
+      if (msg.role !== 'assistant' || !msg.usage) continue;
+
+      const usage = msg.usage;
+      if (usage.input == null && usage.output == null) continue;
+
+      const entryId = obj.id;
+      if (entryId) {
+        if (seenEntryIds.has(entryId)) continue;
+        seenEntryIds.add(entryId);
+      }
+
+      entries.push({
+        source,
+        model: msg.model || msg.modelId || obj.model || obj.modelId || 'unknown',
+        project,
+        timestamp: ts,
+        inputTokens: numberOrZero(usage.input),
+        outputTokens: numberOrZero(usage.output),
+        cachedInputTokens: numberOrZero(usage.cacheRead),
+        reasoningOutputTokens: 0,
+      });
+    }
+  }
+
+  return { buckets: aggregateToBuckets(entries), sessions: extractSessions(sessionEvents) };
+}

--- a/src/tools.js
+++ b/src/tools.js
@@ -104,6 +104,12 @@ function findCodexDataDirs() {
   ].filter(existsSync);
 }
 
+function findCraftAgentDataDirs() {
+  const envDir = process.env.CRAFT_AGENT_DIR || process.env.CRAFTAGENT_DIR;
+  const root = envDir ? join(envDir, 'workspaces') : join(homedir(), '.craft-agent', 'workspaces');
+  return existsSync(root) ? [root] : [];
+}
+
 // Kimi Code moved its store from ~/.kimi to ~/.kimi-code; recognize either so
 // users on either version are detected. The parser prefers ~/.kimi-code.
 function findKimiCodeDataDirs() {
@@ -136,6 +142,12 @@ export const TOOLS = [
     id: 'codex',
     dataDir: join(homedir(), '.codex', 'sessions'),
     detectDataDirs: findCodexDataDirs,
+  },
+  {
+    name: 'CraftAgent',
+    id: 'craft-agent',
+    dataDir: join(homedir(), '.craft-agent', 'workspaces'),
+    detectDataDirs: findCraftAgentDataDirs,
   },
   {
     name: 'GitHub Copilot CLI',

--- a/test/parsers/craft-agent.test.js
+++ b/test/parsers/craft-agent.test.js
@@ -62,3 +62,40 @@ test('craft-agent parser reads pi-compatible JSONL usage', async () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('craft-agent parser falls back to session directory when cwd is missing', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-craft-agent-'));
+  const oldEnv = process.env.CRAFT_AGENT_DIR;
+
+  try {
+    process.env.CRAFT_AGENT_DIR = root;
+
+    const sessionDir = join(root, 'workspaces', 'code-space', 'sessions', 'fresh-branch', '.pi-sessions');
+    mkdirSync(sessionDir, { recursive: true });
+
+    writeFileSync(join(sessionDir, 'session.jsonl'), [
+      JSON.stringify({ type: 'session', id: 'session-1', timestamp: '2026-06-30T15:00:00.000Z' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'a1',
+        timestamp: '2026-06-30T15:01:20.000Z',
+        message: {
+          role: 'assistant',
+          model: 'gpt-test',
+          content: [],
+          usage: { input: 100, output: 20, cacheRead: 30 },
+        },
+      }),
+      '',
+    ].join('\n'));
+
+    const result = await parseCraftAgent();
+
+    assert.equal(result.buckets.length, 1);
+    assert.equal(result.buckets[0].project, 'fresh-branch');
+  } finally {
+    if (oldEnv == null) delete process.env.CRAFT_AGENT_DIR;
+    else process.env.CRAFT_AGENT_DIR = oldEnv;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/parsers/craft-agent.test.js
+++ b/test/parsers/craft-agent.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { parse as parseCraftAgent } from '../../src/parsers/craft-agent.js';
+
+test('craft-agent parser reads pi-compatible JSONL usage', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-craft-agent-'));
+  const oldEnv = process.env.CRAFT_AGENT_DIR;
+
+  try {
+    process.env.CRAFT_AGENT_DIR = root;
+
+    const sessionDir = join(root, 'workspaces', 'code-space', 'sessions', 'fresh-branch', '.pi-sessions');
+    mkdirSync(sessionDir, { recursive: true });
+
+    writeFileSync(join(sessionDir, 'session.jsonl'), [
+      JSON.stringify({ type: 'session', id: 'session-1', timestamp: '2026-06-30T15:00:00.000Z', cwd: '/repo/project-alpha' }),
+      JSON.stringify({ type: 'message', id: 'u1', timestamp: '2026-06-30T15:01:00.000Z', message: { role: 'user', content: [] } }),
+      '{not-json',
+      JSON.stringify({ type: 'message', id: 'a0', timestamp: '2026-06-30T15:01:10.000Z', message: { role: 'assistant', model: 'gpt-test', content: [] } }),
+      JSON.stringify({
+        type: 'message',
+        id: 'a1',
+        timestamp: '2026-06-30T15:01:20.000Z',
+        message: {
+          role: 'assistant',
+          model: 'gpt-test',
+          content: [],
+          usage: { input: 100, output: 20, cacheRead: 30, cacheWrite: 10, totalTokens: 150, cost: { total: 0.01 } },
+        },
+      }),
+      JSON.stringify({ type: 'message', id: 't1', timestamp: '2026-06-30T15:01:25.000Z', message: { role: 'toolResult', content: [] } }),
+      '',
+    ].join('\n'));
+
+    const result = await parseCraftAgent();
+
+    assert.equal(result.buckets.length, 1);
+    assert.deepEqual(result.buckets[0], {
+      source: 'craft-agent',
+      model: 'gpt-test',
+      project: 'project-alpha',
+      bucketStart: '2026-06-30T15:00:00.000Z',
+      inputTokens: 100,
+      outputTokens: 20,
+      cachedInputTokens: 30,
+      reasoningOutputTokens: 0,
+      totalTokens: 120,
+    });
+
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].source, 'craft-agent');
+    assert.equal(result.sessions[0].project, 'project-alpha');
+    assert.equal(result.sessions[0].messageCount, 4);
+    assert.equal(result.sessions[0].userMessageCount, 1);
+  } finally {
+    if (oldEnv == null) delete process.env.CRAFT_AGENT_DIR;
+    else process.env.CRAFT_AGENT_DIR = oldEnv;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

这个 PR 为 `vibe-usage` 增加了 CraftAgent 的本地用量统计支持。

CraftAgent 会在本机保存 Pi-compatible JSONL 会话日志，本 PR 新增 `craft-agent` parser，从以下路径读取日志：

```text
~/.craft-agent/workspaces/{workspace}/sessions/{session}/.pi-sessions/*.jsonl
```

解析 assistant message 中的 token usage，并转换为 `vibe-usage` 现有的 bucket/session 数据结构。

---

## 改动内容

本 PR 主要包含以下改动：

- 新增 CraftAgent parser：
  - `src/parsers/craft-agent.js`
- 新增共享的 Pi-compatible JSONL parser helper：
  - `src/parsers/pi-session-jsonl.js`
- 重构已有的 Pi Coding Agent parser，复用共享 JSONL parser：
  - `src/parsers/pi-coding-agent.js`
- 注册新的 `craft-agent` source：
  - `src/parsers/index.js`
- 在 CLI status 检测中加入 CraftAgent：
  - `src/tools.js`
- 新增 CraftAgent parser 测试：
  - `test/parsers/craft-agent.test.js`
- 为项目增加 `npm test` 脚本，使用 Node.js 内置 test runner。
- 更新 README / AGENTS 文档，说明 CraftAgent 支持。

---

## 统计字段

CraftAgent parser 当前会统计以下信息：

- `source`
- `model`
- `project`
- `bucketStart`
- `inputTokens`
- `outputTokens`
- `cachedInputTokens`
- `reasoningOutputTokens`
- `totalTokens`
- session 活跃信息，例如 message count、user message count、active seconds 等

CraftAgent 日志中的 usage 大致形态如下：

```js
message.usage = {
  input,
  output,
  cacheRead,
  cacheWrite,
  totalTokens,
  cost
}
```

当前映射关系：

- `usage.input` → `inputTokens`
- `usage.output` → `outputTokens`
- `usage.cacheRead` → `cachedInputTokens`
- `reasoningOutputTokens` 当前设为 `0`

暂未映射：

- `usage.cost`
- `usage.cacheWrite`

原因是当前 `vibe-usage` 的 bucket schema 暂时没有对应的 cost/cache write 字段。为了避免污染现有数据结构，本 PR 只接入现有 schema 已支持的 token 字段。

---

## 项目名识别逻辑

CraftAgent 日志里如果存在 `session.cwd`，parser 会优先使用 `cwd` 的最后一级目录作为 project 名。

如果日志缺少 `session.cwd`，parser 会从路径中的 session 目录名回退推断：

```text
~/.craft-agent/workspaces/{workspace}/sessions/{session}/.pi-sessions/*.jsonl
                                                   ^^^^^^^^^
```

这样可以避免直接回退到较宽泛的 workspace 名，例如 `code-space`。

---

## 设计说明

这个实现刻意把 CraftAgent 支持放在 CLI parser 层，而不是 App 层。

原因是：

- CLI 负责读取和解析本地工具日志；
- App 只负责展示服务端返回的 usage buckets；
- 这样可以避免在 App 中重复实现不同工具的日志解析逻辑；
- 也能保持 `vibe-usage` 现有架构边界清晰。

另外，CraftAgent 的日志格式与已有的 Pi Coding Agent JSONL 格式比较接近，因此本 PR 抽出了一个共享 helper：

```text
src/parsers/pi-session-jsonl.js
```

让 `pi-coding-agent` 和 `craft-agent` 共用同一套 JSONL 解析、usage 抽取、session 聚合逻辑，避免复制重复 parser 代码。

---

## 本机测试日志

测试时间：

```text
2026-07-01 23:01 GMT+8
```

### git diff --check

```text
通过，无输出。
```

### npm test

```text
> @vibe-cafe/vibe-usage@0.9.4 test
> node --test

TAP version 13
# Subtest: craft-agent parser reads pi-compatible JSONL usage
ok 1 - craft-agent parser reads pi-compatible JSONL usage
  ---
  duration_ms: 8.808708
  type: 'test'
  ...
# Subtest: craft-agent parser falls back to session directory when cwd is missing
ok 2 - craft-agent parser falls back to session directory when cwd is missing
  ---
  duration_ms: 2.961125
  type: 'test'
  ...
1..2
# tests 2
# suites 0
# pass 2
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 432.639084
```

### vibe-usage status

```text
Detected tools:
  Antigravity
  Claude Code
  Cline
  Codex CLI
  CraftAgent
  Gemini CLI
  Droid

All supported tools:
  CraftAgent: installed
```

### 真实 CraftAgent 日志解析

使用当前本机真实 CraftAgent 日志重新解析：

```text
buckets: 457
sessions: 195
```

最近 5 个 bucket 示例：

```json
[
  {
    "source": "craft-agent",
    "model": "gpt-5.5",
    "project": "code-space",
    "bucketStart": "2026-07-01T15:00:00.000Z",
    "inputTokens": 135393,
    "outputTokens": 860,
    "cachedInputTokens": 131072,
    "reasoningOutputTokens": 0,
    "totalTokens": 136253
  },
  {
    "source": "craft-agent",
    "model": "gpt-5.5",
    "project": "code-space",
    "bucketStart": "2026-07-01T14:30:00.000Z",
    "inputTokens": 197173,
    "outputTokens": 5933,
    "cachedInputTokens": 116224,
    "reasoningOutputTokens": 0,
    "totalTokens": 203106
  },
  {
    "source": "craft-agent",
    "model": "gpt-5.5",
    "project": "future",
    "bucketStart": "2026-07-01T14:30:00.000Z",
    "inputTokens": 16934,
    "outputTokens": 2251,
    "cachedInputTokens": 0,
    "reasoningOutputTokens": 0,
    "totalTokens": 19185
  },
  {
    "source": "craft-agent",
    "model": "gpt-5.5",
    "project": "code-space",
    "bucketStart": "2026-07-01T14:00:00.000Z",
    "inputTokens": 198443,
    "outputTokens": 2534,
    "cachedInputTokens": 130560,
    "reasoningOutputTokens": 0,
    "totalTokens": 200977
  },
  {
    "source": "craft-agent",
    "model": "gpt-5.5",
    "project": "code-space",
    "bucketStart": "2026-07-01T10:30:00.000Z",
    "inputTokens": 62376,
    "outputTokens": 1800,
    "cachedInputTokens": 0,
    "reasoningOutputTokens": 0,
    "totalTokens": 64176
  }
]
```

---

## 备注

本 PR 暂不处理 cost 统计。

CraftAgent 日志中虽然包含 `usage.cost`，但当前 `vibe-usage` 的 bucket/ingest schema 没有 cost 字段。后续如果项目决定支持 cost，可以在 schema 层增加专门字段后再接入。

本 PR 的目标保持简单明确：

> 让 `vibe-usage` 能够读取 CraftAgent 本地日志，并统计 token usage。