### PR TITLE
feat: add support for Trae CLI token usage parsing

### DIFF
--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -17,6 +17,7 @@ import { parse as parseHermes } from './hermes.js';
 import { parse as parseKiro } from './kiro.js';
 import { parse as parsePiCodingAgent } from './pi-coding-agent.js';
 import { parse as parseZcode } from './zcode.js';
+import { parse as parseTraeCli } from './trae-cli.js';
 
 export const parsers = {
   'claude-code': parseClaudeCode,
@@ -37,6 +38,7 @@ export const parsers = {
   'kiro': parseKiro,
   'pi-coding-agent': parsePiCodingAgent,
   'zcode': parseZcode,
+  'trae-cli': parseTraeCli,
 };
 
 

--- a/src/parsers/trae-cli.js
+++ b/src/parsers/trae-cli.js
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { findTraeCliDataDirs } from '../tools.js';
+import { aggregateToBuckets, extractSessions } from './index.js';
+
+function readJsonSafe(path) {
+  try { return JSON.parse(readFileSync(path, 'utf-8')); } catch { return null; }
+}
+
+function projectFromPath(absPath) {
+  if (!absPath || typeof absPath !== 'string') return 'unknown';
+  const trimmed = absPath.replace(/[\\/]+$/, '');
+  const name = basename(trimmed);
+  return name || 'unknown';
+}
+
+function parseJsonlSafe(path) {
+  try {
+    const content = readFileSync(path, 'utf-8');
+    return content
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+      .map(line => {
+        try { return JSON.parse(line); } catch { return null; }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export async function parse() {
+  const cacheDirs = findTraeCliDataDirs();
+  if (cacheDirs.length === 0) return { buckets: [], sessions: [] };
+
+  const entries = [];
+  const events = [];
+
+  for (const cacheDir of cacheDirs) {
+    let sessionDirs = [];
+    try {
+      sessionDirs = readdirSync(cacheDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name);
+    } catch {
+      continue;
+    }
+
+    for (const sessionId of sessionDirs) {
+      const sessionPath = join(cacheDir, sessionId);
+      const sessionJson = readJsonSafe(join(sessionPath, 'session.json')) || {};
+      const project = projectFromPath(sessionJson.metadata?.cwd);
+      const fallbackModel = sessionJson.metadata?.model_name || 'trae-unknown';
+
+      // 1. Parse traces.jsonl for token usage
+      const traceLines = parseJsonlSafe(join(sessionPath, 'traces.jsonl'));
+      const tracesMap = new Map();
+
+      for (const line of traceLines) {
+        if (!line.traceID) continue;
+        const tags = Array.isArray(line.tags) ? line.tags : [];
+        const tagMap = {};
+        for (const t of tags) {
+          if (t && typeof t === 'object' && t.key) {
+            tagMap[t.key] = t.value;
+          }
+        }
+
+        const model = tagMap['model.name'] || tagMap['semantic.name'] || null;
+        const inputTokens = Math.max(0, Number(tagMap['usage.input_tokens']) || 0);
+        const outputTokens = Math.max(0, Number(tagMap['usage.output_tokens']) || 0);
+        const cacheReadTokens = Math.max(0, Number(tagMap['usage.cache_read_tokens']) || 0);
+        const reasoningTokens = Math.max(0, Number(tagMap['usage.reasoning_tokens']) || 0);
+
+        if (inputTokens + outputTokens + cacheReadTokens + reasoningTokens === 0) {
+          continue;
+        }
+
+        if (!tracesMap.has(line.traceID)) {
+          tracesMap.set(line.traceID, {
+            model,
+            inputTokens,
+            outputTokens,
+            cacheReadTokens,
+            reasoningTokens,
+            startTime: Number(line.startTime) || 0,
+          });
+        } else {
+          // Merge spans under the same traceID by selecting the max values
+          const existing = tracesMap.get(line.traceID);
+          if (model) {
+            existing.model = model;
+          }
+          existing.inputTokens = Math.max(existing.inputTokens, inputTokens);
+          existing.outputTokens = Math.max(existing.outputTokens, outputTokens);
+          existing.cacheReadTokens = Math.max(existing.cacheReadTokens, cacheReadTokens);
+          existing.reasoningTokens = Math.max(existing.reasoningTokens, reasoningTokens);
+          if (line.startTime) {
+            existing.startTime = existing.startTime ? Math.min(existing.startTime, Number(line.startTime)) : Number(line.startTime);
+          }
+        }
+      }
+
+      // Convert trace map to vibe-usage entries
+      for (const [traceID, trace] of tracesMap) {
+        // Convert microsecond startTime to milliseconds for Date constructor
+        const timestamp = new Date(trace.startTime / 1000);
+        entries.push({
+          source: 'trae-cli',
+          model: trace.model || fallbackModel,
+          project,
+          timestamp,
+          inputTokens: trace.inputTokens,
+          outputTokens: trace.outputTokens,
+          cachedInputTokens: trace.cacheReadTokens,
+          reasoningOutputTokens: trace.reasoningTokens,
+        });
+      }
+
+      // 2. Parse events.jsonl for user and assistant timings
+      const eventLines = parseJsonlSafe(join(sessionPath, 'events.jsonl'));
+      for (const line of eventLines) {
+        if (!line.created_at) continue;
+        const timestamp = new Date(line.created_at);
+
+        if (line.agent_start) {
+          events.push({
+            sessionId,
+            source: 'trae-cli',
+            project,
+            timestamp,
+            role: 'user',
+          });
+        } else if (line.agent_end || line.tool_call || (line.message && line.message.message?.role === 'assistant')) {
+          events.push({
+            sessionId,
+            source: 'trae-cli',
+            project,
+            timestamp,
+            role: 'assistant',
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    buckets: aggregateToBuckets(entries),
+    sessions: extractSessions(events),
+  };
+}

--- a/src/tools.js
+++ b/src/tools.js
@@ -113,7 +113,29 @@ function findKimiCodeDataDirs() {
   ].filter(existsSync);
 }
 
+export function findTraeCliDataDirs() {
+  const envDir = process.env.VIBE_USAGE_TRAE_CLI_SESSIONS?.trim();
+  if (envDir) {
+    return [envDir].filter(existsSync);
+  }
+  if (process.platform === 'darwin') {
+    return [join(homedir(), 'Library', 'Caches', 'trae-cli', 'sessions')].filter(existsSync);
+  }
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA?.trim() || join(homedir(), 'AppData', 'Local');
+    return [join(localAppData, 'trae-cli', 'cache', 'sessions')].filter(existsSync);
+  }
+  const xdgCacheHome = process.env.XDG_CACHE_HOME?.trim() || join(homedir(), '.cache');
+  return [join(xdgCacheHome, 'trae-cli', 'sessions')].filter(existsSync);
+}
+
 export const TOOLS = [
+  {
+    name: 'Trae CLI',
+    id: 'trae-cli',
+    dataDir: join(homedir(), 'Library', 'Caches', 'trae-cli', 'sessions'),
+    detectDataDirs: findTraeCliDataDirs,
+  },
   {
     name: 'Antigravity',
     id: 'antigravity',

--- a/test/trae-cli.test.js
+++ b/test/trae-cli.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse } from '../src/parsers/trae-cli.js';
+
+test('parse reads Trae CLI session cache logs and aggregates tokens', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-trae-cli-test-'));
+  const sessionsDir = join(root, 'sessions');
+  mkdirSync(sessionsDir, { recursive: true });
+
+  const sessionUUID = '892e9718-b764-4dad-ab5c-ea2e3d2a5828';
+  const sessionPath = join(sessionsDir, sessionUUID);
+  mkdirSync(sessionPath, { recursive: true });
+
+  // Mock session.json
+  writeFileSync(join(sessionPath, 'session.json'), JSON.stringify({
+    id: sessionUUID,
+    created_at: '2026-07-07T20:57:03.162922+08:00',
+    updated_at: '2026-07-07T21:58:38.438473+08:00',
+    metadata: {
+      cwd: '/Users/park0er/coding/Foundations/AgentSetups',
+      model_name: 'GLM-5.2',
+      permission_mode: 'bypass_permissions',
+      title: '扫码完成了'
+    }
+  }));
+
+  // Mock traces.jsonl
+  writeFileSync(join(sessionPath, 'traces.jsonl'), [
+    JSON.stringify({
+      traceID: '8ee89a9cbeb9641ebdbe9fe16e9129c9',
+      spanID: 'c24432205ceac7a5',
+      operationName: 'Doubao-Seed-2.1-Pro',
+      startTime: 1783429023825200,
+      tags: [
+        { key: 'span.category', type: 'string', value: 'model.stream.eino' },
+        { key: 'model.name', type: 'string', value: 'Doubao-Seed-2.1-Pro' },
+        { key: 'usage.input_tokens', type: 'int64', value: 22503 },
+        { key: 'usage.output_tokens', type: 'int64', value: 641 },
+        { key: 'usage.total_tokens', type: 'int64', value: 23144 },
+        { key: 'usage.cache_read_tokens', type: 'int64', value: 5944 },
+        { key: 'usage.reasoning_tokens', type: 'int64', value: 578 }
+      ]
+    }),
+    JSON.stringify({
+      traceID: '8ee89a9cbeb9641ebdbe9fe16e9129c9',
+      spanID: '4d01c049e62044ef',
+      operationName: 'Doubao-Seed-2.1-Pro',
+      startTime: 1783429023825100,
+      tags: [
+        { key: 'span.category', type: 'string', value: 'model.real_call' },
+        { key: 'usage.input_tokens', type: 'int64', value: 22503 },
+        { key: 'usage.output_tokens', type: 'int64', value: 641 },
+        { key: 'usage.cache_read_tokens', type: 'int64', value: 5944 },
+        { key: 'usage.reasoning_tokens', type: 'int64', value: 0 }
+      ]
+    })
+  ].join('\n') + '\n');
+
+  // Mock events.jsonl
+  writeFileSync(join(sessionPath, 'events.jsonl'), [
+    JSON.stringify({
+      id: 'e0bcb513-39b4-4447-8e22-93c74144ce56',
+      session_id: sessionUUID,
+      created_at: '2026-07-07T20:57:03.2208+08:00',
+      agent_start: {}
+    }),
+    JSON.stringify({
+      id: '2752eeb1-d99f-4b0c-9bf4-35c59660d241',
+      session_id: sessionUUID,
+      created_at: '2026-07-07T20:57:03.521842+08:00',
+      message: { message: { role: 'assistant', content: 'hello' } }
+    })
+  ].join('\n') + '\n');
+
+  // Override env path for test
+  const prevTraeCliSessions = process.env.VIBE_USAGE_TRAE_CLI_SESSIONS;
+  process.env.VIBE_USAGE_TRAE_CLI_SESSIONS = sessionsDir;
+
+  try {
+    const result = await parse();
+
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].source, 'trae-cli');
+    assert.equal(result.sessions[0].project, 'AgentSetups');
+
+    assert.equal(result.buckets.length, 1);
+    const bucket = result.buckets[0];
+    assert.equal(bucket.source, 'trae-cli');
+    assert.equal(bucket.model, 'Doubao-Seed-2.1-Pro');
+    assert.equal(bucket.project, 'AgentSetups');
+    assert.equal(bucket.inputTokens, 22503);
+    assert.equal(bucket.outputTokens, 641);
+    assert.equal(bucket.cachedInputTokens, 5944);
+    assert.equal(bucket.reasoningOutputTokens, 578);
+    assert.equal(bucket.totalTokens, 22503 + 641 + 578);
+  } finally {
+    if (prevTraeCliSessions) {
+      process.env.VIBE_USAGE_TRAE_CLI_SESSIONS = prevTraeCliSessions;
+    } else {
+      delete process.env.VIBE_USAGE_TRAE_CLI_SESSIONS;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# feat: add support for Trae CLI token usage parsing

This PR adds tracking support for ByteDance's **Trae CLI** token consumption and session metrics by parsing local telemetry logs.

## Problem Solved

Users of the AI-native editor Trae (specifically using its terminal-based CLI tool or integrations that run the CLI in the background) could not track their token usage within `vibe-usage`. 

### Scope Limitation & Clarification
- **Trae CLI**: Telemetry and LLM transaction traces are written as plain-text JSON Lines (`traces.jsonl` and `events.jsonl`) under the cache session directories. This PR successfully implements a parser to scan and aggregate these logs.
- **Trae Work (IDE Side Panel Agent)**: The desktop GUI side panel runs via a bundled Node native dynamic library (`libai_agent.dylib`) and stores session data inside a SQLCipher encrypted SQLite database (`database.db`) with a dynamically generated key. It does not write unencrypted local logs. **Therefore, native IDE panel chat sessions are NOT supported by this PR.**

## How it was Solved

1. **Cross-Platform Path Resolution**:
   - Added a `findTraeCliDataDirs()` helper to locate CLI cache directories dynamically:
     - **macOS**: `~/Library/Caches/trae-cli/sessions/`
     - **Windows**: `%LOCALAPPDATA%/trae-cli/cache/sessions/`
     - **Linux**: `~/.cache/trae-cli/sessions/`
   - Added support for `process.env.VIBE_USAGE_TRAE_CLI_SESSIONS` to facilitate mock testing.

2. **Telemetry Log Parsing (`src/parsers/trae-cli.js`)**:
   - Scans subdirectories (session UUIDs) in the CLI cache directory.
   - Parses `session.json` to resolve the current workspace directory (mapped to the project name) and the fallback model.
   - Parses `traces.jsonl`: extracts `usage.input_tokens`, `usage.output_tokens`, `usage.cache_read_tokens`, and `usage.reasoning_tokens` for each model call. Spans are grouped by `traceID` to de-duplicate and prevent double-counting of multiple spans mapping to a single LLM invocation.
   - Parses `events.jsonl`: tracks `agent_start` (user) and message/tool events (assistant) to compute session duration and active interaction timings.

3. **Registry & Testing**:
   - Registered `'trae-cli'` in `src/tools.js` and `src/parsers/index.js`.
   - Added a new unit test suite `test/trae-cli.test.js` covering mock traces/events logs and verifying correct aggregation.

## Verification

1. **Unit Tests**:
   - Ran `npm test` successfully (all 8 tests passing, including the new parser).
2. **CLI Integration**:
   - Running `vibe-usage status` correctly lists `Trae CLI` as `installed` and `detected`.
   - Running `vibe-usage sync` parses and uploads Trae CLI telemetry entries successfully.
