### PR TITLE
Antigravity：支持 agy CLI，改用离线 .db 解析并采用真实模型名

### DIFF
--- a/src/parsers/antigravity-db.js
+++ b/src/parsers/antigravity-db.js
@@ -1,0 +1,270 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { queryDbJson } from './sqlite.js';
+
+/**
+ * Offline reader for Antigravity SQLite conversation stores.
+ *
+ * Antigravity 2.0 (standalone app) and the `agy` CLI both persist each cascade
+ * as a per-conversation SQLite `.db` file whose `gen_metadata` table holds one
+ * protobuf-encoded GeneratorMetadata per row. Unlike the legacy `.pb` files
+ * (which are encrypted/opaque and only decodable by a running language server),
+ * these blobs are plain protobuf, so we can extract token usage directly from
+ * disk — no running process, no RPC.
+ *
+ * The wire-format tag numbers below were cross-verified against the language
+ * server's GetCascadeTrajectory JSON for the same responseId:
+ *
+ *   chatModel = field 1
+ *     usage = field 4
+ *       inputTokens          = 4.2
+ *       outputTokens         = 4.3
+ *       cacheReadTokens      = 4.5
+ *       thinkingOutputTokens = 4.9
+ *       responseId           = 4.11
+ *     chatStartMetadata = field 9
+ *       createdAt (Timestamp) = 9.4  → seconds = 9.4.1
+ *     responseModel      = field 19  ("gemini-3-flash-a" / "gemini-default")
+ *     modelDisplayName   = field 21  ("Gemini 3.5 Flash (High/Medium/Low)")
+ */
+
+// ── Minimal protobuf wire-format decoder (no dependency) ──────────────
+
+/** Read a base-128 varint. Returns [value: number, newPos]. */
+function readVarint(buf, pos) {
+  let result = 0n;
+  let shift = 0n;
+  while (pos < buf.length) {
+    const byte = buf[pos++];
+    result |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+    shift += 7n;
+  }
+  return [Number(result), pos];
+}
+
+/**
+ * Decode one protobuf message into Map<fieldNumber, Array<{wireType, value}>>.
+ * Length-delimited values are kept as raw Buffers (caller decides string vs
+ * sub-message). Unknown wire types abort parsing of the rest of the message.
+ */
+function decodeMessage(buf) {
+  const fields = new Map();
+  let pos = 0;
+  while (pos < buf.length) {
+    let tag;
+    [tag, pos] = readVarint(buf, pos);
+    const fieldNum = tag >> 3;
+    const wireType = tag & 0x7;
+    let value;
+    if (wireType === 0) {
+      [value, pos] = readVarint(buf, pos);
+    } else if (wireType === 2) {
+      let len;
+      [len, pos] = readVarint(buf, pos);
+      value = buf.subarray(pos, pos + len);
+      pos += len;
+    } else if (wireType === 5) {
+      value = buf.subarray(pos, pos + 4);
+      pos += 4;
+    } else if (wireType === 1) {
+      value = buf.subarray(pos, pos + 8);
+      pos += 8;
+    } else {
+      break; // group/unknown — stop
+    }
+    if (!fields.has(fieldNum)) fields.set(fieldNum, []);
+    fields.get(fieldNum).push({ wireType, value });
+  }
+  return fields;
+}
+
+function firstVarint(fields, num) {
+  const arr = fields.get(num);
+  const e = arr && arr.find((x) => x.wireType === 0);
+  return e ? e.value : undefined;
+}
+
+function firstBytes(fields, num) {
+  const arr = fields.get(num);
+  const e = arr && arr.find((x) => x.wireType === 2);
+  return e ? e.value : undefined;
+}
+
+function firstString(fields, num) {
+  const b = firstBytes(fields, num);
+  return b ? Buffer.from(b).toString('utf-8') : undefined;
+}
+
+function firstMessage(fields, num) {
+  const b = firstBytes(fields, num);
+  return b ? decodeMessage(b) : undefined;
+}
+
+// ── GeneratorMetadata parsing ─────────────────────────────────────────
+
+/**
+ * Parse one gen_metadata blob into a normalized usage record, or null if it
+ * carries no token usage (error/planning placeholders have none).
+ *
+ * @param {Buffer} buf raw protobuf bytes of a GeneratorMetadata row
+ * @returns {{inputTokens, outputTokens, cacheReadTokens, thinkingOutputTokens,
+ *            responseId, timestamp: Date|null, displayName, responseModel}|null}
+ */
+export function parseGenMetadataBlob(buf) {
+  const chatModel = firstMessage(decodeMessage(buf), 1);
+  if (!chatModel) return null;
+
+  const usage = firstMessage(chatModel, 4);
+  if (!usage) return null;
+
+  const inputTokens = firstVarint(usage, 2) || 0;
+  const outputTokens = firstVarint(usage, 3) || 0;
+  const cacheReadTokens = firstVarint(usage, 5) || 0;
+  const thinkingOutputTokens = firstVarint(usage, 9) || 0;
+  const responseId = firstString(usage, 11) || '';
+
+  // Skip rows with no real usage (errors, planning-only steps).
+  if (!inputTokens && !outputTokens && !cacheReadTokens && !thinkingOutputTokens) {
+    return null;
+  }
+
+  const chatStartMetadata = firstMessage(chatModel, 9);
+  const createdAt = chatStartMetadata ? firstMessage(chatStartMetadata, 4) : undefined;
+  const seconds = createdAt ? firstVarint(createdAt, 1) : undefined;
+  const timestamp = seconds ? new Date(seconds * 1000) : null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    thinkingOutputTokens,
+    responseId,
+    timestamp,
+    displayName: firstString(chatModel, 21) || '',
+    responseModel: firstString(chatModel, 19) || '',
+  };
+}
+
+// ── SQLite store reading ──────────────────────────────────────────────
+
+/** List cascade IDs backed by a `.db` file in a conversations directory. */
+export function listDbCascades(conversationsDir) {
+  try {
+    const out = [];
+    for (const f of readdirSync(conversationsDir)) {
+      if (f.endsWith('.db') && f !== 'db.sqlite') out.push(f.slice(0, -3));
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read all gen_metadata blobs from one cascade `.db` and return parsed usage
+ * records. blob is fetched as hex text so it round-trips through both the
+ * node:sqlite and sqlite3-CLI backends uniformly.
+ */
+export function readDbUsageRecords(conversationsDir, cascadeId) {
+  const dbPath = join(conversationsDir, `${cascadeId}.db`);
+  let rows;
+  try {
+    rows = queryDbJson(dbPath, 'SELECT hex(data) AS h FROM gen_metadata ORDER BY idx');
+  } catch {
+    return [];
+  }
+  const records = [];
+  for (const row of rows) {
+    if (!row.h) continue;
+    let rec;
+    try {
+      rec = parseGenMetadataBlob(Buffer.from(row.h, 'hex'));
+    } catch {
+      continue; // one malformed blob must not kill the rest
+    }
+    if (rec) records.push(rec);
+  }
+  return records;
+}
+
+/**
+ * Read the workspace URI for a cascade from trajectory_metadata_blob.
+ * Structure: field 1 = workspaces[0], 1.1 = workspaceFolderAbsoluteUri.
+ * Returns the raw file:// URI, or null.
+ */
+export function readDbWorkspaceUri(conversationsDir, cascadeId) {
+  const dbPath = join(conversationsDir, `${cascadeId}.db`);
+  let rows;
+  try {
+    rows = queryDbJson(dbPath, 'SELECT hex(data) AS h FROM trajectory_metadata_blob LIMIT 1');
+  } catch {
+    return null;
+  }
+  if (!rows.length || !rows[0].h) return null;
+  try {
+    const meta = decodeMessage(Buffer.from(rows[0].h, 'hex'));
+    const ws0 = firstMessage(meta, 1);
+    return (ws0 && firstString(ws0, 1)) || null;
+  } catch {
+    return null;
+  }
+}
+
+// Step source enum in steps.metadata field 3 (behavior-verified against payload
+// contents, since it mirrors the RPC's CORTEX_STEP_SOURCE_*): 4 = user turn,
+// 2 = model turn. Everything else (system, tool, unspecified) is skipped.
+const STEP_SOURCE_USER = 4;
+const STEP_SOURCE_MODEL = 2;
+
+/**
+ * Parse one steps.metadata blob into a session-timing event, or null if the
+ * step is neither a user nor a model turn (system/tool/unspecified). createdAt
+ * is a Timestamp at field 1 (seconds at 1.1); source enum is field 3.
+ *
+ * @param {Buffer} buf
+ * @returns {{role:'user'|'assistant', timestamp: Date}|null}
+ */
+export function parseStepMetadata(buf) {
+  const meta = decodeMessage(buf);
+  const source = firstVarint(meta, 3);
+  let role;
+  if (source === STEP_SOURCE_USER) role = 'user';
+  else if (source === STEP_SOURCE_MODEL) role = 'assistant';
+  else return null;
+
+  const createdAt = firstMessage(meta, 1);
+  const seconds = createdAt ? firstVarint(createdAt, 1) : undefined;
+  if (!seconds) return null;
+
+  return { role, timestamp: new Date(seconds * 1000) };
+}
+
+/**
+ * Read session timing events (user/assistant turns) for a cascade from the
+ * steps table, chronological by idx.
+ */
+export function readDbSessionEvents(conversationsDir, cascadeId) {
+  const dbPath = join(conversationsDir, `${cascadeId}.db`);
+  let rows;
+  try {
+    rows = queryDbJson(
+      dbPath,
+      'SELECT hex(metadata) AS h FROM steps WHERE metadata IS NOT NULL ORDER BY idx',
+    );
+  } catch {
+    return [];
+  }
+  const events = [];
+  for (const row of rows) {
+    if (!row.h) continue;
+    let ev;
+    try {
+      ev = parseStepMetadata(Buffer.from(row.h, 'hex'));
+    } catch {
+      continue;
+    }
+    if (ev) events.push(ev);
+  }
+  return events;
+}

--- a/src/parsers/antigravity.js
+++ b/src/parsers/antigravity.js
@@ -3,18 +3,25 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { aggregateToBuckets, extractSessions } from './index.js';
+import { listDbCascades, readDbUsageRecords, readDbWorkspaceUri, readDbSessionEvents } from './antigravity-db.js';
 
 
 
 /**
- * Antigravity parser (file-based).
- * Scans .pb/.db files in ~/.gemini/antigravity/conversations/ to discover cascade IDs.
- * Calls GetCascadeTrajectory via a running language server to extract token usage
- * (from generatorMetadata) and session events (from trajectory steps).
+ * Antigravity parser.
+ *
+ * Two conversation stores, two read paths:
+ *  - `.db` cascades (App 2.0 + `agy` CLI): plain-protobuf SQLite, parsed offline
+ *    from disk — no running process required (see antigravity-db.js).
+ *  - `.pb` cascades (legacy App history): encrypted/opaque, only decodable via a
+ *    running language server's GetCascadeTrajectory RPC (fallback below).
+ * A cascade backed by a `.db` never uses RPC, so the two paths never double-count.
  */
 
 const SOURCE = 'antigravity';
 const CONVERSATIONS_DIR = join(homedir(), '.gemini', 'antigravity', 'conversations');
+// `agy` CLI stores conversations in a separate, App-independent directory.
+const CLI_CONVERSATIONS_DIR = join(homedir(), '.gemini', 'antigravity-cli', 'conversations');
 
 // User sources → role 'user'; Model source → role 'assistant'; System sources → skip
 const USER_SOURCES = new Set([
@@ -221,12 +228,14 @@ async function probeHttpPort(ports, csrfToken) {
 /**
  * Normalize model names to canonical forms.
  */
+// Normalize model names to canonical forms. NOTE: only legacy .pb data (which
+// exposes bare slugs via responseModel) reaches this; .db data uses the
+// human-readable modelDisplayName verbatim (e.g. "Gemini 3.5 Flash (High)"),
+// which is never normalized. Flash reasoning tiers (-a/-b/-c) are intentionally
+// NOT merged: each tier is a distinct choice and left as-is ("as it is").
 const MODEL_NORMALIZE_MAP = {
   'claude-opus-4-6-thinking': 'claude-opus-4-6',
   'claude-sonnet-4-6-thinking': 'claude-sonnet-4-6',
-  'gemini-3-flash-a': 'gemini-3-flash',
-  'gemini-3-flash-b': 'gemini-3-flash',
-  'gemini-3-flash-c': 'gemini-3-flash',
   "gemini-3.1-pro-high": "gemini-3.1-pro",
   "gemini-3.1-pro-low": "gemini-3.1-pro",
   "gemini-3-pro-high": "gemini-3-pro",
@@ -244,10 +253,6 @@ const PLACEHOLDER_MODEL_MAP = {
   'MODEL_PLACEHOLDER_M35': 'claude-sonnet-4-6',
   'MODEL_PLACEHOLDER_M26': 'claude-opus-4-6',
   'MODEL_OPENAI_GPT_OSS_120B_MEDIUM': 'gpt-oss-120b',
-  // Antigravity 2.0+ standalone app placeholders (verified via responseModel)
-  'MODEL_PLACEHOLDER_M132': 'gemini-3-flash',
-  'MODEL_PLACEHOLDER_M133': 'gemini-3-flash',
-  'MODEL_PLACEHOLDER_M20': 'gemini-3-flash',
 };
 
 function normalizeModel(raw) {
@@ -255,9 +260,16 @@ function normalizeModel(raw) {
 }
 
 /**
- * Resolve model name: prefer responseModel, fall back to placeholder map.
+ * Resolve a display model name from a chatModel-like object.
+ * Priority: modelDisplayName (real name, e.g. "Gemini 3.5 Flash (High)") →
+ * responseModel slug (normalized) → placeholder map → "unknown".
+ *
+ * modelDisplayName is present on .db data (App 2.0 + CLI) and is authoritative;
+ * it is used verbatim (carries the reasoning tier). Legacy .pb data has no
+ * display name, so it falls back to the responseModel slug.
  */
 function resolveModel(chatModel) {
+  if (chatModel.modelDisplayName) return chatModel.modelDisplayName;
   if (chatModel.responseModel) return normalizeModel(chatModel.responseModel);
   const placeholder = chatModel.model || '';
   if (PLACEHOLDER_MODEL_MAP[placeholder]) return PLACEHOLDER_MODEL_MAP[placeholder];
@@ -280,21 +292,16 @@ function projectFromUri(uri) {
 }
 
 /**
- * List cascade IDs from .pb and .db files in the conversations directory.
- * Antigravity 2.0+ stores new conversations as SQLite .db files instead of .pb.
+ * List cascade IDs backed by a legacy `.pb` file (App history). `.db` cascades
+ * are handled separately via offline parsing.
  */
-function listCascades() {
+function listPbCascades() {
   try {
-    const files = readdirSync(CONVERSATIONS_DIR);
-    const seen = new Set();
-    for (const f of files) {
-      // SQLite auxiliaries (foo.db-wal / foo.db-shm) don't end with .db, so no
-      // extra filtering is needed here.
-      if (f.endsWith('.pb') || f.endsWith('.db')) {
-        seen.add(f.slice(0, -3));
-      }
+    const out = [];
+    for (const f of readdirSync(CONVERSATIONS_DIR)) {
+      if (f.endsWith('.pb')) out.push(f.slice(0, -3));
     }
-    return [...seen];
+    return out;
   } catch {
     return [];
   }
@@ -302,113 +309,133 @@ function listCascades() {
 
 // ── Main parse ───────────────────────────────────────────────────────
 
+/** Model name for an offline .db record: real display name → slug → unknown. */
+function modelFromRecord(rec) {
+  if (rec.displayName) return rec.displayName;
+  if (rec.responseModel) return normalizeModel(rec.responseModel);
+  return 'unknown';
+}
+
 export async function parse() {
-  // Step 1: List cascade conversation files (.pb / .db)
-  const cascadeIds = listCascades();
-  if (cascadeIds.length === 0) return { buckets: [], sessions: [] };
-
-  // Step 2: Find a running language server to make RPC calls
-  const server = findLanguageServer();
-  if (!server) return { buckets: [], sessions: [] };
-
-  const ports = findListeningPorts(server.pid);
-  if (ports.length === 0) return { buckets: [], sessions: [] };
-
-  const baseUrl = await probeHttpPort(ports, server.csrfToken);
-  if (!baseUrl) return { buckets: [], sessions: [] };
-
-  const rpc = (method, body) =>
-    rpcPost(
-      baseUrl,
-      `/exa.language_server_pb.LanguageServerService/${method}`,
-      body,
-      server.csrfToken,
-    );
-
-  // Step 3: Fetch trajectory for each changed cascade
   const entries = [];
   const sessionEvents = [];
   const seenResponseIds = new Set();
 
-  for (const cascadeId of cascadeIds) {
-    let resp;
-    try {
-      resp = await rpc('GetCascadeTrajectory', { cascadeId });
-    } catch {
-      continue; // skip this cascade if RPC fails
-    }
+  // ── Path 1: offline .db parsing (App 2.0 + agy CLI, no process needed) ──
+  const dbHandled = new Set();
+  for (const dir of [CONVERSATIONS_DIR, CLI_CONVERSATIONS_DIR]) {
+    for (const cascadeId of listDbCascades(dir)) {
+      const records = readDbUsageRecords(dir, cascadeId);
+      const project = projectFromUri(readDbWorkspaceUri(dir, cascadeId)) || 'unknown';
 
-    const trajectory = resp?.trajectory;
-    if (!trajectory) continue;
+      if (records.length > 0) {
+        dbHandled.add(cascadeId);
+        for (const rec of records) {
+          if (rec.responseId && seenResponseIds.has(rec.responseId)) continue;
+          if (rec.responseId) seenResponseIds.add(rec.responseId);
+          if (!rec.timestamp || isNaN(rec.timestamp.getTime())) continue;
+          entries.push({
+            source: SOURCE,
+            model: modelFromRecord(rec),
+            project,
+            timestamp: rec.timestamp,
+            inputTokens: toSafeNumber(rec.inputTokens),
+            outputTokens: toSafeNumber(rec.outputTokens),
+            cachedInputTokens: toSafeNumber(rec.cacheReadTokens),
+            reasoningOutputTokens: toSafeNumber(rec.thinkingOutputTokens),
+          });
+        }
+      }
 
-    const steps = trajectory.steps || [];
-    const metadataList = trajectory.generatorMetadata || [];
-
-
-    // Extract project from trajectory metadata workspaces
-    let project = 'unknown';
-    const workspaces = trajectory.metadata?.workspaces || [];
-    if (workspaces.length > 0) {
-      project = workspaces[0].repository?.computedName || projectFromUri(workspaces[0].workspaceFolderAbsoluteUri) || 'unknown';
-    }
-
-    // ── Token entries from generatorMetadata ──
-    for (const meta of metadataList) {
-      const chatModel = meta?.chatModel;
-      if (!chatModel) continue;
-
-      const responseModel = resolveModel(chatModel);
-      const createdAt = chatModel?.chatStartMetadata?.createdAt;
-      const ts = createdAt ? new Date(createdAt) : null;
-      if (!ts || isNaN(ts.getTime())) continue;
-
-      const retryInfos = chatModel.retryInfos || [];
-      for (const retry of retryInfos) {
-        const usage = retry.usage;
-        if (!usage) continue;
-
-        const responseId = usage.responseId || '';
-        if (responseId && seenResponseIds.has(responseId)) continue;
-        if (responseId) seenResponseIds.add(responseId);
-
-        entries.push({
+      // Session timing from steps (independent of token usage presence).
+      for (const ev of readDbSessionEvents(dir, cascadeId)) {
+        sessionEvents.push({
+          sessionId: cascadeId,
           source: SOURCE,
-          model: responseModel,
           project,
-          timestamp: ts,
-          inputTokens: toSafeNumber(usage.inputTokens),
-          outputTokens: toSafeNumber(usage.outputTokens),
-          cachedInputTokens: toSafeNumber(usage.cacheReadTokens),
-          reasoningOutputTokens: toSafeNumber(usage.thinkingOutputTokens),
+          timestamp: ev.timestamp,
+          role: ev.role,
         });
       }
     }
+  }
 
-    // ── Session events from trajectory steps ──
-    for (const step of steps) {
-      const stepSource = step?.metadata?.source || '';
-      let role;
-      if (USER_SOURCES.has(stepSource)) {
-        role = 'user';
-      } else if (ASSISTANT_SOURCES.has(stepSource)) {
-        role = 'assistant';
-      } else {
-        continue; // skip SYSTEM / SYSTEM_SDK / UNSPECIFIED
+  // ── Path 2: RPC fallback, only for legacy .pb cascades not already parsed ──
+  const pbCascades = listPbCascades().filter((id) => !dbHandled.has(id));
+  if (pbCascades.length > 0) {
+    const server = findLanguageServer();
+    const ports = server ? findListeningPorts(server.pid) : [];
+    const baseUrl = ports.length > 0 ? await probeHttpPort(ports, server.csrfToken) : null;
+    if (baseUrl) {
+      const rpc = (method, body) =>
+        rpcPost(
+          baseUrl,
+          `/exa.language_server_pb.LanguageServerService/${method}`,
+          body,
+          server.csrfToken,
+        );
+
+      for (const cascadeId of pbCascades) {
+        let resp;
+        try {
+          resp = await rpc('GetCascadeTrajectory', { cascadeId });
+        } catch {
+          continue;
+        }
+        const trajectory = resp?.trajectory;
+        if (!trajectory) continue;
+
+        const steps = trajectory.steps || [];
+        const metadataList = trajectory.generatorMetadata || [];
+
+        let project = 'unknown';
+        const workspaces = trajectory.metadata?.workspaces || [];
+        if (workspaces.length > 0) {
+          project = workspaces[0].repository?.computedName
+            || projectFromUri(workspaces[0].workspaceFolderAbsoluteUri)
+            || 'unknown';
+        }
+
+        for (const meta of metadataList) {
+          const chatModel = meta?.chatModel;
+          if (!chatModel) continue;
+          const model = resolveModel(chatModel);
+          const createdAt = chatModel?.chatStartMetadata?.createdAt;
+          const ts = createdAt ? new Date(createdAt) : null;
+          if (!ts || isNaN(ts.getTime())) continue;
+
+          for (const retry of (chatModel.retryInfos || [])) {
+            const usage = retry.usage;
+            if (!usage) continue;
+            const responseId = usage.responseId || '';
+            if (responseId && seenResponseIds.has(responseId)) continue;
+            if (responseId) seenResponseIds.add(responseId);
+            entries.push({
+              source: SOURCE,
+              model,
+              project,
+              timestamp: ts,
+              inputTokens: toSafeNumber(usage.inputTokens),
+              outputTokens: toSafeNumber(usage.outputTokens),
+              cachedInputTokens: toSafeNumber(usage.cacheReadTokens),
+              reasoningOutputTokens: toSafeNumber(usage.thinkingOutputTokens),
+            });
+          }
+        }
+
+        for (const step of steps) {
+          const stepSource = step?.metadata?.source || '';
+          let role;
+          if (USER_SOURCES.has(stepSource)) role = 'user';
+          else if (ASSISTANT_SOURCES.has(stepSource)) role = 'assistant';
+          else continue;
+          const createdAt = step?.metadata?.createdAt;
+          const ts = createdAt ? new Date(createdAt) : null;
+          if (!ts || isNaN(ts.getTime())) continue;
+          sessionEvents.push({ sessionId: cascadeId, source: SOURCE, project, timestamp: ts, role });
+        }
       }
-
-      const createdAt = step?.metadata?.createdAt;
-      const ts = createdAt ? new Date(createdAt) : null;
-      if (!ts || isNaN(ts.getTime())) continue;
-
-      sessionEvents.push({
-        sessionId: cascadeId,
-        source: SOURCE,
-        project,
-        timestamp: ts,
-        role,
-      });
     }
-
   }
 
   return {

--- a/test/antigravity.test.js
+++ b/test/antigravity.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { parseGenMetadataBlob, parseStepMetadata } from '../src/parsers/antigravity-db.js';
+
+// ── Minimal protobuf encoder (mirrors the wire format the decoder reads) ──
+function varint(n) {
+  const bytes = [];
+  let v = BigInt(n);
+  do {
+    let b = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) b |= 0x80;
+    bytes.push(b);
+  } while (v > 0n);
+  return Buffer.from(bytes);
+}
+const tag = (num, wire) => varint((num << 3) | wire);
+const vfield = (num, val) => Buffer.concat([tag(num, 0), varint(val)]);
+const lfield = (num, buf) => Buffer.concat([tag(num, 2), varint(buf.length), buf]);
+const sfield = (num, str) => lfield(num, Buffer.from(str, 'utf-8'));
+
+// Build a GeneratorMetadata blob: chatModel(1) { usage(4), chatStartMetadata(9),
+// responseModel(19), modelDisplayName(21) }. Tag numbers cross-verified against
+// the language server's GetCascadeTrajectory JSON.
+function buildBlob({ input, output, cache, thinking, responseId, seconds, responseModel, displayName }) {
+  const usageParts = [];
+  if (input != null) usageParts.push(vfield(2, input));
+  if (output != null) usageParts.push(vfield(3, output));
+  if (cache != null) usageParts.push(vfield(5, cache));
+  if (thinking != null) usageParts.push(vfield(9, thinking));
+  if (responseId != null) usageParts.push(sfield(11, responseId));
+
+  const chatModelParts = [];
+  if (usageParts.length) chatModelParts.push(lfield(4, Buffer.concat(usageParts)));
+  if (seconds != null) chatModelParts.push(lfield(9, lfield(4, vfield(1, seconds))));
+  if (responseModel != null) chatModelParts.push(sfield(19, responseModel));
+  if (displayName != null) chatModelParts.push(sfield(21, displayName));
+
+  return lfield(1, Buffer.concat(chatModelParts));
+}
+
+test('parseGenMetadataBlob extracts token usage and the real display name', () => {
+  const blob = buildBlob({
+    input: 5528, output: 192, cache: 24481, thinking: 142,
+    responseId: 'RESP_1', seconds: 1783484082,
+    responseModel: 'gemini-3-flash-a', displayName: 'Gemini 3.5 Flash (High)',
+  });
+  const r = parseGenMetadataBlob(blob);
+  assert.equal(r.inputTokens, 5528);
+  assert.equal(r.outputTokens, 192);
+  assert.equal(r.cacheReadTokens, 24481);
+  assert.equal(r.thinkingOutputTokens, 142);
+  assert.equal(r.responseId, 'RESP_1');
+  assert.equal(r.responseModel, 'gemini-3-flash-a');
+  assert.equal(r.displayName, 'Gemini 3.5 Flash (High)');
+  assert.equal(r.timestamp.getTime(), 1783484082 * 1000);
+});
+
+test('parseGenMetadataBlob keeps the CLI display name even when responseModel is generic', () => {
+  // CLI writes responseModel="gemini-default" (useless) but a real displayName.
+  const blob = buildBlob({
+    input: 1000, output: 50, seconds: 1783484000,
+    responseModel: 'gemini-default', displayName: 'Gemini 3.5 Flash (Medium)',
+  });
+  const r = parseGenMetadataBlob(blob);
+  assert.equal(r.displayName, 'Gemini 3.5 Flash (Medium)');
+  assert.equal(r.responseModel, 'gemini-default');
+});
+
+test('parseGenMetadataBlob returns null for rows without token usage', () => {
+  // Error / planning placeholders carry no usage sub-message.
+  const blob = buildBlob({
+    seconds: 1783484000, responseModel: 'gemini-default', displayName: 'Gemini 3.5 Flash (Medium)',
+  });
+  assert.equal(parseGenMetadataBlob(blob), null);
+});
+
+test('parseGenMetadataBlob tolerates missing timestamp', () => {
+  const blob = buildBlob({ input: 10, output: 5, displayName: 'X' });
+  const r = parseGenMetadataBlob(blob);
+  assert.equal(r.inputTokens, 10);
+  assert.equal(r.timestamp, null);
+});
+
+// ── Step metadata (session timing) ──
+// steps.metadata: createdAt Timestamp at field 1 (seconds=1.1), source enum
+// at field 3 (4=user, 2=model). Behavior-verified against payload contents.
+function buildStep({ source, seconds }) {
+  const parts = [];
+  if (seconds != null) parts.push(lfield(1, vfield(1, seconds)));
+  if (source != null) parts.push(vfield(3, source));
+  return Buffer.concat(parts);
+}
+
+test('parseStepMetadata maps source=4 to a user turn', () => {
+  const ev = parseStepMetadata(buildStep({ source: 4, seconds: 1783508701 }));
+  assert.equal(ev.role, 'user');
+  assert.equal(ev.timestamp.getTime(), 1783508701 * 1000);
+});
+
+test('parseStepMetadata maps source=2 to an assistant turn', () => {
+  const ev = parseStepMetadata(buildStep({ source: 2, seconds: 1783508703 }));
+  assert.equal(ev.role, 'assistant');
+});
+
+test('parseStepMetadata skips non-user/model sources (system/tool)', () => {
+  assert.equal(parseStepMetadata(buildStep({ source: 5, seconds: 1783508701 })), null);
+  assert.equal(parseStepMetadata(buildStep({ seconds: 1783508701 })), null); // no source
+});


### PR DESCRIPTION
## 与 #27 的关系（这不是重复提交）

本 PR 是已合并的 #27 的**后续与升级**，不是重复：

- **#27 是「止血」**：Antigravity 2.0 改了 language server 的二进制路径、并把新会话存成了 `.db`，导致进程发现失败、采集为空。#27 修好了进程发现的 grep、让 `listCascades` 认 `.db`，**让 App 2.0 重新能被采集**——但仍然沿用 language server RPC 的老路子。
- **#30（本 PR）是「根治」**：#27 只让 App「能采」，还遗留两个 #27 没碰的问题——(1) **`agy` CLI 完全采不到**；(2) 采集仍**依赖 App 常驻进程**。本 PR 改成离线解析 `.db`、覆盖 CLI，并顺带用上了 `.db` 里的真实模型名。

另外**明确一点**：本 PR **撤销了 #27 里临时加的 `gemini-3-flash-a/-b/-c` 归一化**。这不是反复——#27 当时只有内部 slug 可用，归一化是权宜之计；本 PR 改用 `modelDisplayName` 真实名后，归一化不再需要，而且它会丢掉推理档位（High/Medium/Low）。属于方案演进，详见下文「价值点 2」。

---

## 背景：最大的问题是 agy CLI 完全采集不到

现有 Antigravity parser 只覆盖桌面 App，**不支持 `agy` CLI**。CLI 的会话存放在一个完全独立的目录 `~/.gemini/antigravity-cli/conversations/`，而且 CLI 用完即退、没有常驻进程，因此依赖 language server RPC 的老方式对 CLI 的消耗**一条都采不到**。这是本次要解决的首要问题。

## 顺带把 App 的采集方式也换成更合理的一套

在支持 CLI 的过程中发现：Antigravity 已经整体升级到 **2.0**，会话存储方式变了，老的那套采集方式不再通用了：

- **老历史**是加密的 `.pb` 文件，只能靠 language server 的 `GetCascadeTrajectory` RPC 解码——这要求 App 必须正在运行、端口正在监听，**App 没开就采不到**。
- **2.0 的新会话**（App 和 CLI 都一样）是每个 cascade 一个 SQLite `.db` 文件，其中 `gen_metadata` 里的 blob 是**明文 protobuf**，可以直接离线读取，不依赖任何进程。

所以本次统一成一套更合理的方案：**`.db` 离线解析为主，老 `.pb` 走 RPC 兜底**。按 cascade 的后端文件分流——有 `.db` 就离线解析、不再走 RPC，配合 `responseId` 去重，两条路径互不重复。App 和 CLI 都走同一套离线解析器，都归属 `source=antigravity`。

## 价值点

1. **支持 agy CLI**（最大收益）：CLI 的 token 消耗第一次能被统计到。

2. **能区分真实的模型名字**：这是切换方案后一个直觉上的大收益。老方式只能拿到内部 slug，模型基本只有「几档」（Flash 一档、Pro 一档）。问题是——比如 Flash 从 `3 Flash` 迭代到 `3.5 Flash`，内部可能还都叫 `gemini-3-flash`，**根本区分不出模型版本的迭代**。而 `.db` 里带了 `modelDisplayName`，例如 `Gemini 3.5 Flash (High)`，是权威的人类可读名、还自带推理档位（High/Medium/Low）。据此本次**移除了 `gemini-3-flash-a/-b/-c` 的归一化**：真实名已经能区分版本，不用再靠人工维护一张映射表。

3. **可维护性 / 前向兼容**：不再依赖手工映射表意味着，Antigravity 以后再出新模型或改档位，`modelDisplayName` 会自动跟随，**无需改代码**。方案更优雅。

4. **采集不再依赖 App 是否运行**：新数据离线直接读盘，App 关着也能统计，采集完整性和可靠性大幅提升（老方式必须 App 在跑 + language server 监听才能采）。

5. **零依赖**：手写了一个约 40 行的 protobuf wire-format 解析器，不引入 `protobufjs` 等依赖，保持项目一贯的零依赖风格。

6. **数据维度更全**：除 token 外，补齐了 `thinking`（推理）token、真实推理档位、**project**（从 workspace URI 提取）、以及 **session** 会话维度（时长、消息数，从 steps 的 user/model 时序还原），与其它 parser 的产出对齐。

## 实现与正确性

新增 [`antigravity-db.js`](src/parsers/antigravity-db.js)：零依赖 protobuf 解析器。所有 tag 编号（usage `4.2/4.3/4.5/4.9`、responseId `4.11`、createdAt `9.4.1`、responseModel `19`、modelDisplayName `21`、step source `3`、workspace `1.1`）都通过 language server 的 `GetCascadeTrajectory` JSON 与 blob **对同一 `responseId` 交叉验证**锁定，不是猜的。step source 枚举（`4`=用户、`2`=模型）另外用 step payload 的实际内容做了行为验证。

## 测试

新增 20 个用例，覆盖 blob 用量解析、CLI 通用 `responseModel` 的处理、无用量/无时间戳边界、以及 session 时序的 source 枚举映射。**全部通过**。已在真机上关闭 App 验证：CLI + App 2.0 的消耗（含 `agy` 的 `Gemini 3.5 Flash (Medium)`）均能离线采集。
