### PR TITLE
release: harden Antigravity support for v0.9.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ vibe-usage/
 │   │   ├── kimi-code.js
 │   │   ├── amp.js
 │   │   ├── droid.js
+│   │   ├── antigravity-db.js  # Offline SQLite + protobuf reader for App 2.0 / agy CLI
 │   │   ├── kiro.js            # SQLite (via sqlite.js), JSONL fallback
 │   │   ├── hermes.js          # SQLite (via sqlite.js), multi-profile
 │   │   ├── trae-cli.js        # Trae CLI JSONL telemetry (not Trae IDE/Work)
@@ -90,7 +91,7 @@ Parser pattern:
 - Extract user/assistant timing events → `extractSessions(events)`
 - Handle missing/corrupt files gracefully (try/catch, skip bad lines)
 
-SQLite-backed parsers (cursor, opencode, kiro, hermes):
+SQLite-backed parsers (antigravity, cursor, opencode, kiro, hermes):
 - Use `queryDbJson(dbPath, sql)` from `src/parsers/sqlite.js` — never shell out to `sqlite3` directly. It prefers Node's built-in `node:sqlite` (`DatabaseSync`, opened read-only; Node ≥ 22.5, works on Windows with no extra binary) and falls back to the `sqlite3` CLI on older Node.
 - Rows come back as plain objects (`{ column: value }`), same shape as `sqlite3 -json` — INTEGER → number, TEXT → string, JSON via `json_extract` → string.
 - If neither `node:sqlite` nor the CLI is available the helper throws an `ENOENT`-flavored error; catch it and rethrow `'sqlite3 CLI not found. Install sqlite3 (or use Node >= 22.5) to sync X data.'` so the user gets a hint.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Cline | `<host>/User/globalStorage/saoudrizwan.claude-dev/{state/taskHistory.json,tasks/<id>/ui_messages.json}` (walks all VSCode-fork hosts: Code, Cursor, Windsurf, VSCodium, Trae, ...) |
 | Roo Code | `<host>/User/globalStorage/rooveterinaryinc.roo-cline/{tasks/_index.json,tasks/<id>/{history_item,ui_messages}.json}` (walks all VSCode-fork hosts) |
 | Trae CLI | macOS: `~/Library/Caches/trae-cli/sessions/`; Windows: `%LOCALAPPDATA%/trae-cli/cache/sessions/`; Linux: `~/.cache/trae-cli/sessions/` (CLI telemetry only; Trae IDE/Trae Work chats are not supported) |
-| Antigravity | `~/.gemini/antigravity/conversations/*.pb` / `*.db` to discover cascades, then reads token usage + sessions from the running language server via Connect RPC (process discovered with `ps`/`lsof` on macOS/Linux, PowerShell CIM with a `wmic` fallback on Windows) |
+| Antigravity | App 2.0 `~/.gemini/antigravity/conversations/*.db` and `agy` CLI `~/.gemini/antigravity-cli/conversations/*.db` are parsed offline (tokens, real model display name, project, sessions); legacy App `.pb` history falls back to Connect RPC while the language server is running |
 | ZCode | `~/.zcode/cli/db/db.sqlite` (SQLite; reads the `message` table for per-message tokens, model, and project `cwd`/`root`, joined to `session.directory`) |
 
 ## How It Works

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,4 +54,4 @@ Other available commands:
 
 - Requires initial setup with an API key (run `npx @vibe-cafe/vibe-usage` first)
 - Config is stored at `~/.vibe-usage/config.json`
-- Supports: Claude Code, Codex CLI, Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Qwen Code, Kimi Code, Amp, Droid, Trae CLI, ZCode
+- Supports: Claude Code, Codex CLI, Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Qwen Code, Kimi Code, Amp, Droid, Antigravity, Trae CLI, ZCode

--- a/src/parsers/antigravity-db.js
+++ b/src/parsers/antigravity-db.js
@@ -1,4 +1,5 @@
-import { readdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { queryDbJson } from './sqlite.js';
 
@@ -148,6 +149,41 @@ export function parseGenMetadataBlob(buf) {
 
 // ── SQLite store reading ──────────────────────────────────────────────
 
+function isLockError(err) {
+  return err && typeof err.message === 'string' && /database is locked/i.test(err.message);
+}
+
+function isSqliteUnavailableError(err) {
+  return err && typeof err.message === 'string' && /ENOENT|sqlite3.*not found/i.test(err.message);
+}
+
+function queryCascadeDb(conversationsDir, cascadeId, sql) {
+  const dbPath = join(conversationsDir, `${cascadeId}.db`);
+  try {
+    return queryDbJson(dbPath, sql);
+  } catch (err) {
+    if (isSqliteUnavailableError(err)) {
+      throw new Error('sqlite3 CLI not found. Install sqlite3 (or use Node >= 22.5) to sync Antigravity data.');
+    }
+    if (!isLockError(err)) throw err;
+
+    // The App can hold the live DB open. Query a WAL-consistent snapshot so
+    // one active cascade does not make the whole Antigravity parser go empty.
+    const snapshotDir = mkdtempSync(join(tmpdir(), 'vibe-usage-antigravity-'));
+    const snapshotPath = join(snapshotDir, `${cascadeId}.db`);
+    try {
+      copyFileSync(dbPath, snapshotPath);
+      for (const suffix of ['-shm', '-wal']) {
+        const companion = `${dbPath}${suffix}`;
+        if (existsSync(companion)) copyFileSync(companion, `${snapshotPath}${suffix}`);
+      }
+      return queryDbJson(snapshotPath, sql);
+    } finally {
+      rmSync(snapshotDir, { recursive: true, force: true });
+    }
+  }
+}
+
 /** List cascade IDs backed by a `.db` file in a conversations directory. */
 export function listDbCascades(conversationsDir) {
   try {
@@ -167,11 +203,11 @@ export function listDbCascades(conversationsDir) {
  * node:sqlite and sqlite3-CLI backends uniformly.
  */
 export function readDbUsageRecords(conversationsDir, cascadeId) {
-  const dbPath = join(conversationsDir, `${cascadeId}.db`);
   let rows;
   try {
-    rows = queryDbJson(dbPath, 'SELECT hex(data) AS h FROM gen_metadata ORDER BY idx');
-  } catch {
+    rows = queryCascadeDb(conversationsDir, cascadeId, 'SELECT hex(data) AS h FROM gen_metadata ORDER BY idx');
+  } catch (err) {
+    if (isSqliteUnavailableError(err)) throw err;
     return [];
   }
   const records = [];
@@ -194,11 +230,11 @@ export function readDbUsageRecords(conversationsDir, cascadeId) {
  * Returns the raw file:// URI, or null.
  */
 export function readDbWorkspaceUri(conversationsDir, cascadeId) {
-  const dbPath = join(conversationsDir, `${cascadeId}.db`);
   let rows;
   try {
-    rows = queryDbJson(dbPath, 'SELECT hex(data) AS h FROM trajectory_metadata_blob LIMIT 1');
-  } catch {
+    rows = queryCascadeDb(conversationsDir, cascadeId, 'SELECT hex(data) AS h FROM trajectory_metadata_blob LIMIT 1');
+  } catch (err) {
+    if (isSqliteUnavailableError(err)) throw err;
     return null;
   }
   if (!rows.length || !rows[0].h) return null;
@@ -245,14 +281,15 @@ export function parseStepMetadata(buf) {
  * steps table, chronological by idx.
  */
 export function readDbSessionEvents(conversationsDir, cascadeId) {
-  const dbPath = join(conversationsDir, `${cascadeId}.db`);
   let rows;
   try {
-    rows = queryDbJson(
-      dbPath,
+    rows = queryCascadeDb(
+      conversationsDir,
+      cascadeId,
       'SELECT hex(metadata) AS h FROM steps WHERE metadata IS NOT NULL ORDER BY idx',
     );
-  } catch {
+  } catch (err) {
+    if (isSqliteUnavailableError(err)) throw err;
     return [];
   }
   const events = [];

--- a/src/tools.js
+++ b/src/tools.js
@@ -113,6 +113,13 @@ function findKimiCodeDataDirs() {
   ].filter(existsSync);
 }
 
+function findAntigravityDataDirs() {
+  return [
+    join(homedir(), '.gemini', 'antigravity'),
+    join(homedir(), '.gemini', 'antigravity-cli'),
+  ].filter(existsSync);
+}
+
 export function findTraeCliDataDirs() {
   const envDir = process.env.VIBE_USAGE_TRAE_CLI_SESSIONS?.trim();
   if (envDir) {
@@ -140,6 +147,7 @@ export const TOOLS = [
     name: 'Antigravity',
     id: 'antigravity',
     dataDir: join(homedir(), '.gemini', 'antigravity'),
+    detectDataDirs: findAntigravityDataDirs,
   },
   {
     name: 'Claude Code',

--- a/test/antigravity.test.js
+++ b/test/antigravity.test.js
@@ -1,6 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { parseGenMetadataBlob, parseStepMetadata } from '../src/parsers/antigravity-db.js';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  listDbCascades,
+  parseGenMetadataBlob,
+  parseStepMetadata,
+  readDbSessionEvents,
+  readDbUsageRecords,
+  readDbWorkspaceUri,
+} from '../src/parsers/antigravity-db.js';
 
 // ── Minimal protobuf encoder (mirrors the wire format the decoder reads) ──
 function varint(n) {
@@ -106,4 +116,51 @@ test('parseStepMetadata maps source=2 to an assistant turn', () => {
 test('parseStepMetadata skips non-user/model sources (system/tool)', () => {
   assert.equal(parseStepMetadata(buildStep({ source: 5, seconds: 1783508701 })), null);
   assert.equal(parseStepMetadata(buildStep({ seconds: 1783508701 })), null); // no source
+});
+
+test('offline DB reader loads usage, workspace, and session events', async (t) => {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import('node:sqlite'));
+  } catch {
+    t.skip('node:sqlite is unavailable on this Node version');
+    return;
+  }
+
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-antigravity-test-'));
+  const conversationsDir = join(root, 'conversations');
+  mkdirSync(conversationsDir, { recursive: true });
+  const cascadeId = 'cascade-1';
+  const db = new DatabaseSync(join(conversationsDir, `${cascadeId}.db`));
+  try {
+    db.exec(`
+      CREATE TABLE gen_metadata (idx INTEGER, data BLOB);
+      CREATE TABLE trajectory_metadata_blob (data BLOB);
+      CREATE TABLE steps (idx INTEGER, metadata BLOB);
+    `);
+    const usageBlob = buildBlob({
+      input: 1000, output: 50, cache: 400, thinking: 25,
+      responseId: 'RESP_DB', seconds: 1783484000,
+      responseModel: 'gemini-default', displayName: 'Gemini 3.5 Flash (Medium)',
+    });
+    const workspaceBlob = lfield(1, sfield(1, 'file:///Users/example/project-one'));
+    db.prepare('INSERT INTO gen_metadata (idx, data) VALUES (?, ?)').run(1, usageBlob);
+    db.prepare('INSERT INTO trajectory_metadata_blob (data) VALUES (?)').run(workspaceBlob);
+    db.prepare('INSERT INTO steps (idx, metadata) VALUES (?, ?)').run(1, buildStep({ source: 4, seconds: 1783484001 }));
+    db.prepare('INSERT INTO steps (idx, metadata) VALUES (?, ?)').run(2, buildStep({ source: 2, seconds: 1783484003 }));
+  } finally {
+    db.close();
+  }
+
+  try {
+    assert.deepEqual(listDbCascades(conversationsDir), [cascadeId]);
+    const records = readDbUsageRecords(conversationsDir, cascadeId);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].displayName, 'Gemini 3.5 Flash (Medium)');
+    assert.equal(records[0].thinkingOutputTokens, 25);
+    assert.equal(readDbWorkspaceUri(conversationsDir, cascadeId), 'file:///Users/example/project-one');
+    assert.deepEqual(readDbSessionEvents(conversationsDir, cascadeId).map((event) => event.role), ['user', 'assistant']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Release follow-up to #30 while keeping the combined #29 + #30 package at 0.9.11:

- detect pure `agy` CLI installations
- surface missing SQLite support on Node <22.5 instead of silently returning no data
- retry locked live databases through a WAL snapshot
- add a real SQLite integration test for usage, workspace, and session extraction
- update README, AGENTS, and SKILL documentation

Verified on the combined release tree: `npm test` (22/22), `npm pack --dry-run`, and `git diff --check`.