### PR TITLE
feat: add DimAgent usage parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Grok | `$GROK_HOME/sessions/<encoded-cwd>/<session-id>/` (default `~/.grok`); token usage from `updates.jsonl` `turn_completed.usage` (per-model `modelUsage`, cache reads, reasoning); project from `summary.json` cwd; honors `GROK_HOME` |
 | GitHub Copilot CLI | `~/.copilot/session-state/*/events.jsonl` |
 | Cursor | `state.vscdb` (SQLite, reads `cursorAuth/accessToken`, fetches CSV from `cursor.com`); cloud data is stamped with a fixed `cursor-cloud` hostname so multi-machine setups don't double-count |
+| DimAgent | `$DIMCODE_HOME/dimcode.sqlite` (default `~/.dimcode/v2/dimcode.sqlite`); exact usage from `usage_ledger`, with forked ledger/history copies deduplicated |
 | Gemini CLI | `~/.gemini/tmp/<project_hash>/chats/session-*.jsonl` (current line-delimited format) and legacy `session-*.json`; recurses into nested subagent sessions |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/`, `~/.openclaw-<profile>/agents/` (profile deployments) |

--- a/src/parsers/dimagent.js
+++ b/src/parsers/dimagent.js
@@ -1,0 +1,133 @@
+import { existsSync } from 'node:fs';
+import { aggregateToBuckets, extractSessions } from './index.js';
+import { queryDbJson } from './sqlite.js';
+import { getDimAgentDbPath } from '../tools.js';
+
+const SOURCE = 'dimagent';
+const FORKED_LEDGER_ID = /^ledger_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function projectName(cwd) {
+  if (!cwd) return 'unknown';
+  const parts = String(cwd).replace(/[/\\]+$/, '').split(/[/\\]/);
+  return parts.at(-1) || 'unknown';
+}
+
+function tokenCount(value) {
+  const count = Number(value);
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
+function usageSignature(row) {
+  return [
+    row.runId || '',
+    row.providerId || '',
+    row.modelId || '',
+    row.usage || '',
+    row.cost ?? '',
+    row.createdAt || '',
+  ].join('\0');
+}
+
+function parseUsageRows(rows) {
+  const entries = [];
+  const originalSignatures = new Set(
+    rows
+      .filter(row => !FORKED_LEDGER_ID.test(row.ledgerId || ''))
+      .map(usageSignature),
+  );
+  const keptOrphanClones = new Set();
+
+  for (const row of rows) {
+    const signature = usageSignature(row);
+    if (FORKED_LEDGER_ID.test(row.ledgerId || '')) {
+      if (originalSignatures.has(signature) || keptOrphanClones.has(signature)) continue;
+      keptOrphanClones.add(signature);
+    }
+
+    let usage;
+    try {
+      usage = typeof row.usage === 'string' ? JSON.parse(row.usage) : row.usage;
+    } catch {
+      continue;
+    }
+    if (!usage || typeof usage !== 'object') continue;
+
+    const timestamp = new Date(row.createdAt);
+    if (Number.isNaN(timestamp.getTime())) continue;
+
+    const promptTokens = tokenCount(usage.promptTokens);
+    const cachedInputTokens = tokenCount(usage.cacheReadTokens);
+    const inputTokens = Math.max(0, promptTokens - cachedInputTokens);
+    const outputTokens = tokenCount(usage.completionTokens);
+    if (inputTokens + outputTokens + cachedInputTokens === 0) continue;
+
+    entries.push({
+      source: SOURCE,
+      model: row.modelId || 'unknown',
+      project: projectName(row.cwd),
+      timestamp,
+      inputTokens,
+      outputTokens,
+      cachedInputTokens,
+      reasoningOutputTokens: 0,
+    });
+  }
+
+  return entries;
+}
+
+function queryDb(dbPath, sql) {
+  try {
+    return queryDbJson(dbPath, sql);
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.status === 127 || err.message?.includes('ENOENT')) {
+      throw new Error('sqlite3 CLI not found. Install sqlite3 (or use Node >= 22.5) to sync DimAgent data.');
+    }
+    throw err;
+  }
+}
+
+export async function parse() {
+  const dbPath = getDimAgentDbPath();
+  if (!existsSync(dbPath)) return { buckets: [], sessions: [] };
+
+  const usageRows = queryDb(dbPath, `SELECT
+    u.ledgerId,
+    u.runId,
+    u.providerId,
+    u.modelId,
+    u.usage,
+    u.cost,
+    u.createdAt,
+    s.cwd
+    FROM usage_ledger u
+    LEFT JOIN sessions s ON s.sessionId = u.sessionId`);
+
+  const messageRows = queryDb(dbPath, `SELECT
+    m.sessionId,
+    m.role,
+    m.createdAt,
+    s.cwd
+    FROM messages m
+    LEFT JOIN sessions s ON s.sessionId = m.sessionId
+    WHERE m.role IN ('user', 'assistant')
+      AND m.messageId NOT LIKE 'msg_fork_%'`);
+
+  const sessionEvents = [];
+  for (const row of messageRows) {
+    const timestamp = new Date(row.createdAt);
+    if (Number.isNaN(timestamp.getTime())) continue;
+    sessionEvents.push({
+      sessionId: row.sessionId,
+      source: SOURCE,
+      project: projectName(row.cwd),
+      timestamp,
+      role: row.role,
+    });
+  }
+
+  return {
+    buckets: aggregateToBuckets(parseUsageRows(usageRows)),
+    sessions: extractSessions(sessionEvents),
+  };
+}

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -4,6 +4,7 @@ import { parse as parseCline } from './cline.js';
 import { parse as parseCodex } from './codex.js';
 import { parse as parseCopilotCli } from './copilot-cli.js';
 import { parse as parseCursor } from './cursor.js';
+import { parse as parseDimAgent } from './dimagent.js';
 import { parse as parseRooCode } from './roo-code.js';
 import { parse as parseGeminiCli } from './gemini-cli.js';
 import { parse as parseGrok } from './grok.js';
@@ -26,6 +27,7 @@ export const parsers = {
   'grok': parseGrok,
   'copilot-cli': parseCopilotCli,
   'cursor': parseCursor,
+  'dimagent': parseDimAgent,
   'gemini-cli': parseGeminiCli,
   'opencode': parseOpencode,
   'openclaw': parseOpenclaw,

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { findClaudeCodeDataDirs } from './claude-roots.js';
 
@@ -145,6 +145,24 @@ export function findGrokDataDirs() {
   return [join(getGrokHome(), 'sessions')].filter(existsSync);
 }
 
+export function getDimAgentDbPath() {
+  const override = process.env.VIBE_USAGE_DIMAGENT_DB?.trim();
+  if (override) return resolve(override);
+
+  const explicitHome = process.env.DIMCODE_HOME?.trim();
+  if (explicitHome) return join(resolve(explicitHome), 'dimcode.sqlite');
+
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME?.trim();
+  const home = xdgConfigHome
+    ? resolve(xdgConfigHome, '.dimcode', 'v2')
+    : join(homedir(), '.dimcode', 'v2');
+  return join(home, 'dimcode.sqlite');
+}
+
+export function findDimAgentDataDirs() {
+  return [getDimAgentDbPath()].filter(existsSync);
+}
+
 export const TOOLS = [
   {
     name: 'Claude Code',
@@ -173,6 +191,12 @@ export const TOOLS = [
     name: 'Cursor',
     id: 'cursor',
     dataDir: getCursorStateDbPath(),
+  },
+  {
+    name: 'DimAgent',
+    id: 'dimagent',
+    dataDir: getDimAgentDbPath(),
+    detectDataDirs: findDimAgentDataDirs,
   },
   {
     name: 'Gemini CLI',

--- a/test/dimagent.test.js
+++ b/test/dimagent.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse } from '../src/parsers/dimagent.js';
+
+test('parse reads DimAgent SQLite usage and excludes forked copies', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-dimagent-test-'));
+  const dbPath = join(root, 'dimcode.sqlite');
+  const previousDbPath = process.env.VIBE_USAGE_DIMAGENT_DB;
+
+  execFileSync('sqlite3', [dbPath, `
+    CREATE TABLE sessions (
+      sessionId TEXT PRIMARY KEY,
+      cwd TEXT NOT NULL
+    );
+    CREATE TABLE usage_ledger (
+      ledgerId TEXT PRIMARY KEY,
+      sessionId TEXT NOT NULL,
+      runId TEXT,
+      providerId TEXT NOT NULL,
+      modelId TEXT NOT NULL,
+      usage TEXT NOT NULL,
+      cost REAL,
+      createdAt TEXT NOT NULL
+    );
+    CREATE TABLE messages (
+      messageId TEXT PRIMARY KEY,
+      sessionId TEXT NOT NULL,
+      role TEXT NOT NULL,
+      createdAt TEXT NOT NULL
+    );
+
+    INSERT INTO sessions VALUES
+      ('main', '/work/example-app'),
+      ('fork', '/work/example-app'),
+      ('fork-2', '/work/example-app');
+
+    INSERT INTO usage_ledger VALUES
+      ('usage_run-1', 'main', 'run-1', 'dim', 'gpt-main',
+       '{"promptTokens":100,"completionTokens":20,"totalTokens":120,"cacheReadTokens":40}',
+       NULL, '2026-07-01T00:10:00.000Z'),
+      ('ledger_11111111-1111-4111-8111-111111111111', 'fork', 'run-1', 'dim', 'gpt-main',
+       '{"promptTokens":100,"completionTokens":20,"totalTokens":120,"cacheReadTokens":40}',
+       NULL, '2026-07-01T00:10:00.000Z'),
+      ('plugin_ledger_original', 'main', NULL, 'dim', 'plugin-model',
+       '{"promptTokens":30,"completionTokens":5,"totalTokens":35}',
+       NULL, '2026-07-01T00:20:00.000Z'),
+      ('ledger_22222222-2222-4222-8222-222222222222', 'fork', NULL, 'dim', 'plugin-model',
+       '{"promptTokens":30,"completionTokens":5,"totalTokens":35}',
+       NULL, '2026-07-01T00:20:00.000Z'),
+      ('ledger_33333333-3333-4333-8333-333333333333', 'fork', NULL, 'dim', 'orphan-model',
+       '{"promptTokens":50,"completionTokens":10,"totalTokens":60,"cacheReadTokens":20}',
+       NULL, '2026-07-01T00:25:00.000Z'),
+      ('ledger_44444444-4444-4444-8444-444444444444', 'fork-2', NULL, 'dim', 'orphan-model',
+       '{"promptTokens":50,"completionTokens":10,"totalTokens":60,"cacheReadTokens":20}',
+       NULL, '2026-07-01T00:25:00.000Z'),
+      ('ledger_1700000000000_1', 'main', NULL, 'dim', 'cache-write-model',
+       '{"promptTokens":80,"completionTokens":8,"totalTokens":88,"cacheReadTokens":20,"cacheWriteTokens":30}',
+       NULL, '2026-07-01T00:26:00.000Z'),
+      ('bad-json', 'main', NULL, 'dim', 'bad-model',
+       '{', NULL, '2026-07-01T00:27:00.000Z');
+
+    INSERT INTO messages VALUES
+      ('main-user-1', 'main', 'user', '2026-07-01T00:00:00.000Z'),
+      ('main-assistant-1', 'main', 'assistant', '2026-07-01T00:00:05.000Z'),
+      ('main-assistant-2', 'main', 'assistant', '2026-07-01T00:00:10.000Z'),
+      ('main-user-2', 'main', 'user', '2026-07-01T00:05:00.000Z'),
+      ('main-assistant-3', 'main', 'assistant', '2026-07-01T00:05:03.000Z'),
+      ('msg_fork_1_user', 'fork', 'user', '2026-07-01T00:00:00.000Z'),
+      ('msg_fork_1_assistant', 'fork', 'assistant', '2026-07-01T00:00:10.000Z'),
+      ('fork-user', 'fork', 'user', '2026-07-01T00:06:00.000Z'),
+      ('fork-assistant', 'fork', 'assistant', '2026-07-01T00:06:04.000Z');
+  `]);
+
+  process.env.VIBE_USAGE_DIMAGENT_DB = dbPath;
+  try {
+    const result = await parse();
+    const byModel = Object.fromEntries(result.buckets.map(bucket => [bucket.model, bucket]));
+
+    assert.deepEqual(
+      {
+        inputTokens: byModel['gpt-main'].inputTokens,
+        outputTokens: byModel['gpt-main'].outputTokens,
+        cachedInputTokens: byModel['gpt-main'].cachedInputTokens,
+      },
+      { inputTokens: 60, outputTokens: 20, cachedInputTokens: 40 },
+    );
+    assert.equal(byModel['plugin-model'].inputTokens, 30);
+    assert.equal(byModel['orphan-model'].inputTokens, 30);
+    assert.equal(byModel['cache-write-model'].inputTokens, 60);
+    assert.equal(result.buckets.length, 4);
+
+    assert.equal(result.sessions.length, 2);
+    const mainSession = result.sessions.find(session => session.userMessageCount === 2);
+    const forkSession = result.sessions.find(session => session.userMessageCount === 1);
+    assert.equal(mainSession.project, 'example-app');
+    assert.equal(mainSession.messageCount, 5);
+    assert.equal(mainSession.activeSeconds, 5);
+    assert.equal(forkSession.messageCount, 2);
+  } finally {
+    if (previousDbPath === undefined) delete process.env.VIBE_USAGE_DIMAGENT_DB;
+    else process.env.VIBE_USAGE_DIMAGENT_DB = previousDbPath;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Add support for **DimAgent** by parsing token usage and session activity from its local SQLite database.

## Why

[DimAgent](http://dimagent.com/) stores exact model usage locally, but vibe-usage currently cannot discover or sync it.

## How

DimAgent stores its data in `$DIMCODE_HOME/dimcode.sqlite` (default `~/.dimcode/v2/dimcode.sqlite`):

- `usage_ledger` provides exact per-run and plugin token usage
- `sessions` provides the project working directory
- `messages` provides user/assistant timing events

The parser:

- separates cache-read tokens from prompt tokens to match vibe-usage bucket semantics
- deduplicates ledger rows copied by DimAgent forks
- excludes copied `msg_fork_*` history while retaining new fork/sub-agent activity
- preserves one orphaned fork copy if its original ledger row was deleted
- honors `DIMCODE_HOME`, `XDG_CONFIG_HOME`, and a fixture-only database override

## Files

- `src/parsers/dimagent.js` — new SQLite parser
- `src/parsers/index.js` — register the `dimagent` source
- `src/tools.js` — discover the DimAgent database
- `test/dimagent.test.js` — cover token normalization and fork deduplication
- `README.md` — document support and the data location

## Test

```text
npm test
85 tests passed
```

The parser was also checked against a real `~/.dimcode/v2/dimcode.sqlite`; its token totals matched a direct canonical-ledger SQL aggregation.

## Note

The backend `USAGE_SOURCES` allowlist also needs to accept `dimagent`. Until then, the ingest API soft-drops those buckets; current sync behavior leaves unknown-source hashes uncommitted so they are retried after the backend is updated.
