### PR TITLE
Add normalizeModelName() to unify model aliases (k3, moonshot/kimi-k3, etc.)

### DIFF
--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -55,6 +55,40 @@ export function roundToHalfHour(date) {
 const MODEL_MAX_LENGTH = 100;
 const PROJECT_MAX_LENGTH = 200;
 
+// Known model aliases: some APIs use short model IDs that differ from the
+// canonical name the pricing table expects. Map them so all variants land in
+// the same server-side bucket and receive the correct price lookup.
+const MODEL_ALIASES = {
+  // Kimi For Coding (api.kimi.com/coding/v1) uses "k3" for the Kimi K3
+  // flagship; Moonshot AI API and resellers use "kimi-k3".
+  k3: 'kimi-k3',
+};
+
+/**
+ * Normalize a raw model name so the server can price it consistently.
+ *
+ * 1. Strip provider/namespace prefix:
+ *    "moonshot/kimi-k3" → "kimi-k3"
+ *    "anthropic/claude-opus-4.8" → "claude-opus-4.8"
+ *
+ * 2. Map known short aliases to canonical names:
+ *    "k3" → "kimi-k3"
+ *
+ * 3. Clamp to the server's varchar(100) column limit.
+ */
+export function normalizeModelName(rawModel) {
+  let model = String(rawModel || 'unknown').trim();
+  const slashIndex = model.lastIndexOf('/');
+  if (slashIndex >= 0) {
+    model = model.slice(slashIndex + 1);
+  }
+  const aliased = MODEL_ALIASES[model];
+  if (aliased) {
+    model = aliased;
+  }
+  return model.slice(0, MODEL_MAX_LENGTH);
+}
+
 // Server token columns are bigint — a single fractional/NaN value aborts the
 // whole INSERT chunk with 22P02, taking every other tool's rows in the batch
 // down with it.
@@ -68,7 +102,7 @@ export function aggregateToBuckets(entries) {
   const map = new Map();
 
   for (const e of entries) {
-    const model = String(e.model || 'unknown').slice(0, MODEL_MAX_LENGTH);
+    const model = normalizeModelName(e.model);
     const project = String(e.project || 'unknown').slice(0, PROJECT_MAX_LENGTH);
     const bucketStart = roundToHalfHour(e.timestamp).toISOString();
     const key = `${e.source}|${model}|${project}|${e.hostname || ''}|${bucketStart}`;

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { aggregateToBuckets } from '../src/parsers/index.js';
+import { aggregateToBuckets, normalizeModelName } from '../src/parsers/index.js';
 
 function entry(overrides = {}) {
   return {
@@ -70,4 +70,35 @@ test('aggregateToBuckets keeps distinct hostnames in distinct buckets', () => {
     { hostname: 'cursor-cloud', inputTokens: 3 },
     { hostname: undefined, inputTokens: 4 },
   ]);
+});
+
+test('normalizeModelName strips provider prefixes', () => {
+  assert.equal(normalizeModelName('moonshot/kimi-k3'), 'kimi-k3');
+  assert.equal(normalizeModelName('moonshotai/kimi-k3'), 'kimi-k3');
+  assert.equal(normalizeModelName('anthropic/claude-opus-4.8'), 'claude-opus-4.8');
+  assert.equal(normalizeModelName('openai/gpt-5.6-sol'), 'gpt-5.6-sol');
+});
+
+test('normalizeModelName maps known aliases to canonical names', () => {
+  assert.equal(normalizeModelName('k3'), 'kimi-k3');
+  assert.equal(normalizeModelName('moonshot/k3'), 'kimi-k3');
+});
+
+test('normalizeModelName passes through already-canonical names', () => {
+  assert.equal(normalizeModelName('kimi-k3'), 'kimi-k3');
+  assert.equal(normalizeModelName('claude-opus-4.8'), 'claude-opus-4.8');
+  assert.equal(normalizeModelName('gpt-5.6-sol'), 'gpt-5.6-sol');
+});
+
+test('aggregateToBuckets merges alias variants into a single bucket', () => {
+  const buckets = aggregateToBuckets([
+    entry({ model: 'k3', inputTokens: 100 }),
+    entry({ model: 'kimi-k3', inputTokens: 200 }),
+    entry({ model: 'moonshot/kimi-k3', inputTokens: 300 }),
+    entry({ model: 'moonshotai/kimi-k3', inputTokens: 400 }),
+  ]);
+
+  const kimiBuckets = buckets.filter(b => b.model === 'kimi-k3');
+  assert.equal(kimiBuckets.length, 1);
+  assert.equal(kimiBuckets[0].inputTokens, 1000);
 });


### PR DESCRIPTION
## Summary

Adds a 
ormalizeModelName() function in parsers/index.js that runs before bucket aggregation, so all variants of the same model land in one server-side bucket and get the correct price lookup.

## Problem

Different APIs and resellers use different model IDs for the same underlying model. For example, Kimi K3 appears as:

- k3 (Kimi For Coding, api.kimi.com/coding/v1)
- kimi-k3 (Moonshot AI API, api.moonshot.ai/v1)
- moonshot/kimi-k3 (CrossModel)
- moonshotai/kimi-k3 (ZenMux, ambient)

Without normalization, each variant creates a separate bucket. Variants the pricing table does not recognize show \.00 cost (see #37).

## What this PR does

1. **Strips provider prefixes** before the last slash:
   - moonshot/kimi-k3 to kimi-k3
   - anthropic/claude-opus-4.8 to claude-opus-4.8

2. **Maps known short aliases** to canonical names:
   - k3 to kimi-k3

3. **Preserves already-canonical names** unchanged (no-op for claude-opus-4.8, gpt-5.6-sol, etc.)

## Tests added

- normalizeModelName strips provider prefixes
- normalizeModelName maps known aliases to canonical names
- normalizeModelName passes through already-canonical names
- aggregateToBuckets merges alias variants into a single bucket (k3 + kimi-k3 + moonshot/kimi-k3 + moonshotai/kimi-k3 all sum into one kimi-k3 bucket)

All new tests pass. The alias map is a small, extensible object so new mappings can be added as new models ship with non-standard IDs.