### PR TITLE
feat: add MiMoCode usage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | pi | `~/.pi/agent/sessions/` |
 | Qwen Code | `~/.qwen/tmp/` |
 | Kimi Code | Current `~/.kimi-code/sessions/wd_<slug>_<hash>/session_<id>/agents/<agent>/wire.jsonl` (`usage.record` deltas, including retry/compaction scope and cache creation; main/subagent wires form one session), data root resolved via `$KIMI_CODE_HOME` like the CLI itself, with project names from `session_index.jsonl`; legacy `~/.kimi/sessions/` is parsed alongside (`kimi migrate` never carries usage over, so both stores are always merged) |
+| MiMoCode | `$MIMOCODE_HOME/data/mimocode.db`, `$XDG_DATA_HOME/mimocode/mimocode.db`, or `~/.local/share/mimocode/mimocode.db` (SQLite; exact input, output, reasoning, and cache-read tokens from assistant messages; honors `MIMOCODE_DB`; cache-write tokens are not uploaded) |
 | Amp | `~/.local/share/amp/threads/` |
 | Droid | `~/.factory/sessions/` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/<name>/state.db` (SQLite, multi-profile) |

--- a/src/daemon-service.js
+++ b/src/daemon-service.js
@@ -56,10 +56,25 @@ function escapeXml(value) {
     .replace(/'/g, '&apos;');
 }
 
-export function generateSystemdUnit(nodePath, binPath, claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim()) {
-  const claudeEnvironment = claudeConfigDir
-    ? `Environment="CLAUDE_CONFIG_DIR=${escapeSystemdEnvironment(claudeConfigDir)}"\n`
-    : '';
+const PRESERVED_SERVICE_ENV = ['MIMOCODE_HOME', 'MIMOCODE_DB', 'XDG_DATA_HOME'];
+
+function serviceEnvironment(claudeConfigDir, env) {
+  const values = {
+    CLAUDE_CONFIG_DIR: claudeConfigDir,
+    ...Object.fromEntries(PRESERVED_SERVICE_ENV.map(key => [key, env[key]?.trim()])),
+  };
+  return Object.entries(values).filter(([, value]) => value);
+}
+
+export function generateSystemdUnit(
+  nodePath,
+  binPath,
+  claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim(),
+  env = process.env,
+) {
+  const environment = serviceEnvironment(claudeConfigDir, env)
+    .map(([key, value]) => `Environment="${key}=${escapeSystemdEnvironment(value)}"\n`)
+    .join('');
   return `[Unit]
 Description=VibeCafe Usage Tracker
 After=network.target
@@ -70,18 +85,23 @@ ExecStart=${nodePath} ${binPath} daemon
 Restart=on-failure
 RestartSec=10
 Environment=NODE_ENV=production
-${claudeEnvironment}WorkingDirectory=${homedir()}
+${environment}WorkingDirectory=${homedir()}
 
 [Install]
 WantedBy=default.target
 `;
 }
 
-export function generateLaunchdPlist(nodePath, binPath, claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim()) {
+export function generateLaunchdPlist(
+  nodePath,
+  binPath,
+  claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim(),
+  env = process.env,
+) {
   const logDir = join(homedir(), '.vibe-usage');
-  const claudeEnvironment = claudeConfigDir
-    ? `        <key>CLAUDE_CONFIG_DIR</key>\n        <string>${escapeXml(claudeConfigDir)}</string>\n`
-    : '';
+  const environment = serviceEnvironment(claudeConfigDir, env)
+    .map(([key, value]) => `        <key>${key}</key>\n        <string>${escapeXml(value)}</string>\n`)
+    .join('');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -108,7 +128,7 @@ export function generateLaunchdPlist(nodePath, binPath, claudeConfigDir = proces
     <dict>
         <key>NODE_ENV</key>
         <string>production</string>
-${claudeEnvironment}    </dict>
+${environment}    </dict>
 </dict>
 </plist>
 `;

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -16,6 +16,7 @@ import { parse as parseDroid } from './droid.js';
 import { parse as parseAntigravity } from './antigravity.js';
 import { parse as parseHermes } from './hermes.js';
 import { parse as parseKiro } from './kiro.js';
+import { parse as parseMimocode } from './mimocode.js';
 import { parse as parsePiCodingAgent } from './pi-coding-agent.js';
 import { parse as parseZcode } from './zcode.js';
 import { parse as parseTraeCli } from './trae-cli.js';
@@ -38,6 +39,7 @@ export const parsers = {
   'trae-cli': parseTraeCli,
   'hermes': parseHermes,
   'kiro': parseKiro,
+  'mimocode': parseMimocode,
   'cline': parseCline,
   'roo-code': parseRooCode,
   'zcode': parseZcode,

--- a/src/parsers/mimocode.js
+++ b/src/parsers/mimocode.js
@@ -1,0 +1,90 @@
+import { existsSync } from 'node:fs';
+import { basename } from 'node:path';
+import { getMimocodeDbPath } from '../tools.js';
+import { aggregateToBuckets, extractSessions } from './index.js';
+import { queryDbJson } from './sqlite.js';
+
+export { getMimocodeDbPath as resolveMimocodeDbPath };
+
+export async function parse() {
+  const dbPath = getMimocodeDbPath();
+  if (!existsSync(dbPath)) return { buckets: [], sessions: [] };
+
+  let rows;
+  try {
+    const hasExternalImports = queryDbJson(dbPath, `
+      SELECT 1
+      FROM sqlite_master
+      WHERE type = 'table' AND name = 'external_import'
+      LIMIT 1
+    `).length > 0;
+    const externalImportJoin = hasExternalImports
+      ? 'LEFT JOIN external_import ON external_import.session_id = message.session_id'
+      : '';
+    const externalImportFilter = hasExternalImports
+      ? 'WHERE external_import.session_id IS NULL'
+      : '';
+    rows = queryDbJson(dbPath, `
+      SELECT
+        message.session_id AS sessionID,
+        message.time_created AS created,
+        message.data AS data,
+        session.directory AS directory
+      FROM message
+      JOIN session ON session.id = message.session_id
+      ${externalImportJoin}
+      ${externalImportFilter}
+    `);
+  } catch (err) {
+    if (err.status === 127 || err.message?.includes('ENOENT')) {
+      throw new Error('sqlite3 CLI not found. Install sqlite3 (or use Node >= 22.5) to sync MiMoCode data.');
+    }
+    throw err;
+  }
+
+  const entries = [];
+  const events = [];
+  for (const row of rows) {
+    let data;
+    try {
+      data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
+    } catch {
+      continue;
+    }
+    if (data?.role !== 'user' && data?.role !== 'assistant') continue;
+
+    const timestamp = new Date(data.time?.created ?? row.created);
+    if (Number.isNaN(timestamp.getTime())) continue;
+    const project = row.directory ? basename(row.directory) : 'unknown';
+    events.push({
+      sessionId: row.sessionID || 'unknown',
+      source: 'mimocode',
+      project,
+      timestamp,
+      role: data.role,
+    });
+
+    const tokens = data.tokens;
+    if (data.role !== 'assistant' || !data.modelID || !tokens) continue;
+    const inputTokens = (Number(tokens.input) || 0) + (Number(tokens.cache?.write) || 0);
+    const outputTokens = Number(tokens.output) || 0;
+    const reasoningOutputTokens = Number(tokens.reasoning) || 0;
+    const cachedInputTokens = Number(tokens.cache?.read) || 0;
+    if (inputTokens + outputTokens + reasoningOutputTokens + cachedInputTokens <= 0) continue;
+    entries.push({
+      source: 'mimocode',
+      model: data.modelID,
+      project,
+      timestamp,
+      inputTokens,
+      outputTokens,
+      cachedInputTokens,
+      reasoningOutputTokens,
+    });
+  }
+
+  return {
+    buckets: aggregateToBuckets(entries),
+    sessions: extractSessions(events),
+  };
+}

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { homedir } from 'node:os';
 import { findClaudeCodeDataDirs } from './claude-roots.js';
 
@@ -98,6 +98,17 @@ function findKimiCodeDataDirs() {
     join(homedir(), '.kimi-code', 'sessions'),
     join(homedir(), '.kimi', 'sessions'),
   ].filter(existsSync);
+}
+
+export function getMimocodeDbPath(env = process.env) {
+  if (env.MIMOCODE_HOME && !isAbsolute(env.MIMOCODE_HOME)) {
+    throw new Error(`MIMOCODE_HOME must be an absolute path, got: ${JSON.stringify(env.MIMOCODE_HOME)}`);
+  }
+  const dataDir = env.MIMOCODE_HOME
+    ? join(env.MIMOCODE_HOME, 'data')
+    : join(env.XDG_DATA_HOME || join(homedir(), '.local', 'share'), 'mimocode');
+  if (!env.MIMOCODE_DB) return join(dataDir, 'mimocode.db');
+  return isAbsolute(env.MIMOCODE_DB) ? env.MIMOCODE_DB : join(dataDir, env.MIMOCODE_DB);
 }
 
 function findAntigravityDataDirs() {
@@ -207,6 +218,12 @@ export const TOOLS = [
     // path. The parser reads whichever exists (preferring ~/.kimi-code).
     dataDir: join(homedir(), '.kimi-code', 'sessions'),
     detectDataDirs: findKimiCodeDataDirs,
+  },
+  {
+    name: 'MiMoCode',
+    id: 'mimocode',
+    dataDir: join(homedir(), '.local', 'share', 'mimocode', 'mimocode.db'),
+    detectDataDirs: () => [getMimocodeDbPath()].filter(existsSync),
   },
   {
     name: 'Amp',

--- a/test/daemon-service.test.js
+++ b/test/daemon-service.test.js
@@ -15,3 +15,28 @@ test('launchd service preserves and XML-escapes CLAUDE_CONFIG_DIR', () => {
   assert.match(plist, /<key>CLAUDE_CONFIG_DIR<\/key>/);
   assert.match(plist, /<string>\/tmp\/claude&amp;a&lt;b&gt;<\/string>/);
 });
+
+test('systemd service preserves MiMoCode database path overrides', () => {
+  const unit = generateSystemdUnit('/usr/bin/node', '/opt/vibe-usage/bin.js', undefined, {
+    MIMOCODE_HOME: '/tmp/mimo "home"',
+    MIMOCODE_DB: '/tmp/mimo "home"/custom.db',
+    XDG_DATA_HOME: '/tmp/xdg "data"',
+  });
+  assert.match(unit, /Environment="MIMOCODE_HOME=\/tmp\/mimo \\"home\\""/);
+  assert.match(unit, /Environment="MIMOCODE_DB=\/tmp\/mimo \\"home\\"\/custom\.db"/);
+  assert.match(unit, /Environment="XDG_DATA_HOME=\/tmp\/xdg \\"data\\""/);
+});
+
+test('launchd service preserves and XML-escapes MiMoCode database path overrides', () => {
+  const plist = generateLaunchdPlist('/usr/bin/node', '/opt/vibe-usage/bin.js', undefined, {
+    MIMOCODE_HOME: '/tmp/mimo&a<b>',
+    MIMOCODE_DB: '/tmp/mimo&a<b>/custom.db',
+    XDG_DATA_HOME: '/tmp/xdg&a<b>',
+  });
+  assert.match(plist, /<key>MIMOCODE_HOME<\/key>/);
+  assert.match(plist, /<string>\/tmp\/mimo&amp;a&lt;b&gt;<\/string>/);
+  assert.match(plist, /<key>MIMOCODE_DB<\/key>/);
+  assert.match(plist, /<string>\/tmp\/mimo&amp;a&lt;b&gt;\/custom\.db<\/string>/);
+  assert.match(plist, /<key>XDG_DATA_HOME<\/key>/);
+  assert.match(plist, /<string>\/tmp\/xdg&amp;a&lt;b&gt;<\/string>/);
+});

--- a/test/mimocode.test.js
+++ b/test/mimocode.test.js
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse, resolveMimocodeDbPath } from '../src/parsers/mimocode.js';
+import { parsers } from '../src/parsers/index.js';
+import { TOOLS } from '../src/tools.js';
+
+function sqlLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+async function createFixtureDb(dbPath, sql) {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import('node:sqlite'));
+  } catch {
+    // Node 20 exercises the same sqlite3 CLI fallback used by queryDbJson().
+  }
+  if (DatabaseSync) {
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(sql);
+    } finally {
+      db.close();
+    }
+    return;
+  }
+  execFileSync('sqlite3', [dbPath, sql]);
+}
+
+test('MiMoCode is registered as a parser and detected tool', () => {
+  assert.equal(typeof parsers.mimocode, 'function');
+  assert.equal(TOOLS.find(tool => tool.id === 'mimocode')?.name, 'MiMoCode');
+});
+
+test('resolveMimocodeDbPath follows MiMoCode environment precedence', () => {
+  assert.equal(resolveMimocodeDbPath({
+    MIMOCODE_HOME: '/tmp/mimo-home',
+    MIMOCODE_DB: 'channel.db',
+  }), '/tmp/mimo-home/data/channel.db');
+  assert.equal(resolveMimocodeDbPath({
+    MIMOCODE_HOME: '/tmp/mimo-home',
+    MIMOCODE_DB: '/tmp/custom.db',
+  }), '/tmp/custom.db');
+  assert.equal(resolveMimocodeDbPath({
+    XDG_DATA_HOME: '/tmp/xdg-data',
+  }), '/tmp/xdg-data/mimocode/mimocode.db');
+});
+
+test('parse reads exact token usage and session timing from MiMoCode SQLite', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-mimocode-test-'));
+  const dbPath = join(root, 'mimocode.db');
+  const userCreated = Date.parse('2026-07-27T08:00:00.000Z');
+  const assistantCreated = Date.parse('2026-07-27T08:10:00.000Z');
+  await createFixtureDb(dbPath, `
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT NOT NULL
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      INSERT INTO session (id, directory) VALUES ('ses_1', '/repo/mimo-app');
+      INSERT INTO message (id, session_id, time_created, data)
+      VALUES ('msg_user', 'ses_1', ${userCreated}, ${sqlLiteral(JSON.stringify({
+      role: 'user',
+      time: { created: userCreated },
+      model: { modelID: 'mimo-v2.5-pro' },
+    }))});
+      INSERT INTO message (id, session_id, time_created, data)
+      VALUES ('msg_assistant', 'ses_1', ${assistantCreated}, ${sqlLiteral(JSON.stringify({
+      role: 'assistant',
+      time: { created: assistantCreated, completed: assistantCreated + 5_000 },
+      modelID: 'mimo-v2.5-pro',
+      tokens: {
+        input: 120,
+        output: 30,
+        reasoning: 10,
+        cache: { read: 400, write: 20 },
+      },
+    }))});
+  `);
+
+  const previousDb = process.env.MIMOCODE_DB;
+  process.env.MIMOCODE_DB = dbPath;
+  try {
+    const result = await parse();
+    assert.deepEqual(result.buckets, [{
+      source: 'mimocode',
+      model: 'mimo-v2.5-pro',
+      project: 'mimo-app',
+      bucketStart: '2026-07-27T08:00:00.000Z',
+      inputTokens: 140,
+      outputTokens: 30,
+      cachedInputTokens: 400,
+      reasoningOutputTokens: 10,
+      totalTokens: 180,
+    }]);
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].source, 'mimocode');
+    assert.equal(result.sessions[0].project, 'mimo-app');
+    assert.equal(result.sessions[0].firstMessageAt, '2026-07-27T08:00:00.000Z');
+    assert.equal(result.sessions[0].lastMessageAt, '2026-07-27T08:10:00.000Z');
+    assert.equal(result.sessions[0].durationSeconds, 600);
+    assert.equal(result.sessions[0].messageCount, 2);
+    assert.equal(result.sessions[0].userMessageCount, 1);
+  } finally {
+    if (previousDb === undefined) delete process.env.MIMOCODE_DB;
+    else process.env.MIMOCODE_DB = previousDb;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('parse excludes sessions imported from other supported tools', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-mimocode-import-test-'));
+  const dbPath = join(root, 'mimocode.db');
+  const created = Date.parse('2026-07-27T09:00:00.000Z');
+  await createFixtureDb(dbPath, `
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT NOT NULL
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE external_import (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        source TEXT NOT NULL
+      );
+      INSERT INTO session (id, directory) VALUES ('ses_native', '/repo/native');
+      INSERT INTO session (id, directory) VALUES ('ses_imported', '/repo/imported');
+      INSERT INTO external_import (id, session_id, source)
+      VALUES ('import_1', 'ses_imported', 'claude-code');
+      INSERT INTO message (id, session_id, time_created, data)
+      VALUES ('msg_native', 'ses_native', ${created}, ${sqlLiteral(JSON.stringify({
+      role: 'assistant',
+      time: { created },
+      modelID: 'mimo-v2.5-pro',
+      tokens: { input: 10, output: 5 },
+    }))});
+      INSERT INTO message (id, session_id, time_created, data)
+      VALUES ('msg_imported', 'ses_imported', ${created}, ${sqlLiteral(JSON.stringify({
+      role: 'assistant',
+      time: { created },
+      modelID: 'claude-sonnet-4',
+      tokens: { input: 1000, output: 500 },
+    }))});
+  `);
+
+  const previousDb = process.env.MIMOCODE_DB;
+  process.env.MIMOCODE_DB = dbPath;
+  try {
+    const result = await parse();
+    assert.equal(result.buckets.length, 1);
+    assert.equal(result.buckets[0].model, 'mimo-v2.5-pro');
+    assert.equal(result.buckets[0].totalTokens, 15);
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].project, 'native');
+  } finally {
+    if (previousDb === undefined) delete process.env.MIMOCODE_DB;
+    else process.env.MIMOCODE_DB = previousDb;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add a SQLite-backed parser for MiMoCode token usage and session timing
- support the default XDG data path plus `MIMOCODE_HOME` and `MIMOCODE_DB` overrides
- preserve MiMoCode path overrides in generated systemd and launchd services
- exclude sessions imported into MiMoCode from Claude Code, Codex, and OpenCode to prevent duplicate usage
- register MiMoCode in parser/tool detection and document its local data source

## Token mapping

- `tokens.input + tokens.cache.write` → `inputTokens` (consistent with existing cache-creation semantics)
- `tokens.output` → `outputTokens`
- `tokens.reasoning` → `reasoningOutputTokens`
- `tokens.cache.read` → `cachedInputTokens`

## Validation

- current Node: `npm test` — 92/92 passed
- Node 20: 91 passed, 1 unrelated Antigravity test skipped; MiMoCode SQLite tests exercise the `sqlite3` CLI fallback without skips
- verified against the local MiMoCode SQLite database after excluding `external_import` sessions
- SQLite query plan uses an automatic covering index for `external_import.session_id`

## Backend dependency

The backend must add `mimocode` to `USAGE_SOURCES` before shipping this client support. Until then, ingest soft-drops MiMoCode buckets as an unknown source. The backend repository is not accessible from the current GitHub connection, so that paired change is not included in this PR.