### PR TITLE
feat: add oh-my-pi (omp) usage tracking parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Gemini CLI | `~/.gemini/tmp/<project_hash>/chats/session-*.jsonl` (current line-delimited format) and legacy `session-*.json`; recurses into nested subagent sessions |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/`, `~/.openclaw-<profile>/agents/` (profile deployments) |
+| oh-my-pi | `~/.omp/agent/sessions/**/*.jsonl` (pi-fork session format: per-message `usage` input/output/cacheRead/cacheWrite, project from `session` entry `cwd`; honors `OMP_AGENT_DIR`) |
 | pi | `~/.pi/agent/sessions/` |
 | Qwen Code | `~/.qwen/tmp/` |
 | Kimi Code | Current `~/.kimi-code/sessions/wd_<slug>_<hash>/session_<id>/agents/<agent>/wire.jsonl` (`usage.record` deltas, including retry/compaction scope and cache creation; main/subagent wires form one session), data root resolved via `$KIMI_CODE_HOME` like the CLI itself, with project names from `session_index.jsonl`; legacy `~/.kimi/sessions/` is parsed alongside (`kimi migrate` never carries usage over, so both stores are always merged) |

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -16,6 +16,7 @@ import { parse as parseDroid } from './droid.js';
 import { parse as parseAntigravity } from './antigravity.js';
 import { parse as parseHermes } from './hermes.js';
 import { parse as parseKiro } from './kiro.js';
+import { parse as parseOmp } from './omp.js';
 import { parse as parsePiCodingAgent } from './pi-coding-agent.js';
 import { parse as parseZcode } from './zcode.js';
 import { parse as parseTraeCli } from './trae-cli.js';
@@ -29,6 +30,7 @@ export const parsers = {
   'gemini-cli': parseGeminiCli,
   'opencode': parseOpencode,
   'openclaw': parseOpenclaw,
+  'omp': parseOmp,
   'pi-coding-agent': parsePiCodingAgent,
   'qwen-code': parseQwenCode,
   'kimi-code': parseKimiCode,

--- a/src/parsers/omp.js
+++ b/src/parsers/omp.js
@@ -1,0 +1,147 @@
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { aggregateToBuckets, extractSessions } from './index.js';
+
+/**
+ * oh-my-pi (omp) parser.
+ * Reads JSONL session files from ~/.omp/agent/sessions/ (or $OMP_AGENT_DIR/sessions/).
+ *
+ * omp is a fork of pi, so the session format is identical:
+ *   sessions/<encoded-cwd>/{timestamp}_{sessionId}.jsonl
+ *
+ * A companion directory sharing the .jsonl basename may sit next to each
+ * session file (holding *.bash.log etc.) — it is ignored; only *.jsonl is parsed.
+ *
+ * Each JSONL line is a session entry:
+ *   - type "session": header with id, cwd, version
+ *   - type "message": contains message object with role, usage, model, timestamp
+ *   - type "model_change", "mode_change", "custom", etc.: metadata (ignored for usage)
+ *
+ * Assistant messages carry per-message token usage:
+ *   message.usage = { input, output, cacheRead, cacheWrite, totalTokens }
+ */
+
+function getSessionsDir() {
+  const envDir = process.env.OMP_AGENT_DIR;
+  if (envDir) return join(envDir, 'sessions');
+  return join(homedir(), '.omp', 'agent', 'sessions');
+}
+
+function findJsonlFiles(dir) {
+  const results = [];
+  if (!existsSync(dir)) return results;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findJsonlFiles(fullPath));
+      } else if (entry.name.endsWith('.jsonl')) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // ignore unreadable directories
+  }
+  return results;
+}
+
+function extractProjectFromCwd(cwd) {
+  if (!cwd) return 'unknown';
+  const parts = cwd.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
+}
+
+function extractProjectFromDir(filePath, sessionsDir) {
+  const relative = filePath.slice(sessionsDir.length + 1);
+  const firstSeg = relative.split('/')[0] || relative.split('\\')[0];
+  if (!firstSeg) return 'unknown';
+  const parts = firstSeg.split('-').filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : 'unknown';
+}
+
+export async function parse() {
+  const sessionsDir = getSessionsDir();
+  const entries = [];
+  const sessionEvents = [];
+  const seenEntryIds = new Set();
+
+  const sessionFiles = findJsonlFiles(sessionsDir);
+
+  for (const filePath of sessionFiles) {
+    let content;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let sessionId = basename(filePath, '.jsonl');
+    let project = extractProjectFromDir(filePath, sessionsDir);
+
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (obj.type === 'session') {
+        if (obj.id) sessionId = obj.id;
+        if (obj.cwd) project = extractProjectFromCwd(obj.cwd);
+        continue;
+      }
+
+      if (obj.type !== 'message') continue;
+
+      const msg = obj.message;
+      if (!msg) continue;
+
+      let ts;
+      if (obj.timestamp) {
+        ts = new Date(obj.timestamp);
+      } else if (msg.timestamp) {
+        ts = new Date(msg.timestamp);
+      }
+      if (!ts || isNaN(ts.getTime())) continue;
+
+      if (msg.role === 'user' || msg.role === 'assistant' || msg.role === 'toolResult') {
+        sessionEvents.push({
+          sessionId,
+          source: 'omp',
+          project,
+          timestamp: ts,
+          role: msg.role === 'user' ? 'user' : 'assistant',
+        });
+      }
+
+      if (msg.role !== 'assistant') continue;
+      if (!msg.usage) continue;
+
+      const usage = msg.usage;
+      if (usage.input == null && usage.output == null) continue;
+
+      const entryId = obj.id;
+      if (entryId) {
+        if (seenEntryIds.has(entryId)) continue;
+        seenEntryIds.add(entryId);
+      }
+
+      entries.push({
+        source: 'omp',
+        model: msg.model || 'unknown',
+        project,
+        timestamp: ts,
+        inputTokens: usage.input || 0,
+        outputTokens: usage.output || 0,
+        cachedInputTokens: usage.cacheRead || 0,
+        reasoningOutputTokens: 0,
+      });
+    }
+  }
+
+  return { buckets: aggregateToBuckets(entries), sessions: extractSessions(sessionEvents) };
+}

--- a/src/parsers/omp.js
+++ b/src/parsers/omp.js
@@ -19,7 +19,8 @@ import { aggregateToBuckets, extractSessions } from './index.js';
  *   - type "model_change", "mode_change", "custom", etc.: metadata (ignored for usage)
  *
  * Assistant messages carry per-message token usage:
- *   message.usage = { input, output, cacheRead, cacheWrite, totalTokens }
+ *   message.usage = { input, output, cacheRead, cacheWrite, totalTokens,
+ *                       reasoningTokens? }   // reasoningTokens: newer omp builds
  */
 
 function getSessionsDir() {
@@ -138,7 +139,7 @@ export async function parse() {
         inputTokens: usage.input || 0,
         outputTokens: usage.output || 0,
         cachedInputTokens: usage.cacheRead || 0,
-        reasoningOutputTokens: 0,
+        reasoningOutputTokens: usage.reasoningTokens || 0,
       });
     }
   }

--- a/src/tools.js
+++ b/src/tools.js
@@ -191,6 +191,11 @@ export const TOOLS = [
     detectDataDirs: findOpenclawDataDirs,
   },
   {
+    name: 'oh-my-pi',
+    id: 'omp',
+    dataDir: join(homedir(), '.omp', 'agent'),
+  },
+  {
     name: 'pi',
     id: 'pi-coding-agent',
     dataDir: join(homedir(), '.pi', 'agent', 'sessions'),

--- a/test/omp.test.js
+++ b/test/omp.test.js
@@ -25,12 +25,13 @@ function writeSessionFixture(sessionsDir) {
       message: { role, content: [], timestamp: new Date(ts).getTime(), ...extra },
     });
 
-  const usage = (input, output, cacheRead) => ({
+  const usage = (input, output, cacheRead, reasoningTokens = 0) => ({
     input,
     output,
     cacheRead,
     cacheWrite: 0,
     totalTokens: input + output + cacheRead,
+    reasoningTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   });
 
@@ -56,7 +57,7 @@ function writeSessionFixture(sessionsDir) {
     msg('a1', 'u1', '2026-07-27T13:20:10.000Z', 'assistant', {
       provider: 'kimi-code',
       model: 'k3-256k',
-      usage: usage(1000, 200, 5000),
+      usage: usage(1000, 200, 5000, 123),
     }),
     msg('t1', 'a1', '2026-07-27T13:20:12.000Z', 'toolResult'),
     JSON.stringify(duplicate),
@@ -98,6 +99,9 @@ test('parse reads omp assistant usage, dedups entries, and extracts sessions', a
     assert.equal(first.inputTokens, 1000 + 500);
     assert.equal(first.outputTokens, 200 + 100);
     assert.equal(first.cachedInputTokens, 5000 + 2000);
+    // reasoningTokens (newer omp builds) maps to reasoningOutputTokens; the
+    // duplicate entry must not double-count it.
+    assert.equal(first.reasoningOutputTokens, 123);
 
     const second = byStart.get('2026-07-27T13:30:00.000Z');
     assert.ok(second, 'expected 13:30 bucket');

--- a/test/omp.test.js
+++ b/test/omp.test.js
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse } from '../src/parsers/omp.js';
+
+function writeSessionFixture(sessionsDir) {
+  const group = '--home-AI-gf--';
+  const sessionId = '019fa3bb-6ca5-7000-a966-e44970259739';
+  const fileName = `2026-07-27T13-19-57-093Z_${sessionId}.jsonl`;
+  const groupDir = join(sessionsDir, group);
+  mkdirSync(groupDir, { recursive: true });
+
+  // Companion directory with the same basename holding *.bash.log — must be ignored.
+  mkdirSync(join(groupDir, fileName.replace(/\.jsonl$/, '')), { recursive: true });
+  writeFileSync(join(groupDir, fileName.replace(/\.jsonl$/, ''), 'cmd.bash.log'), 'echo hi\n');
+
+  const msg = (id, parentId, ts, role, extra = {}) =>
+    JSON.stringify({
+      type: 'message',
+      id,
+      parentId,
+      timestamp: ts,
+      message: { role, content: [], timestamp: new Date(ts).getTime(), ...extra },
+    });
+
+  const usage = (input, output, cacheRead) => ({
+    input,
+    output,
+    cacheRead,
+    cacheWrite: 0,
+    totalTokens: input + output + cacheRead,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  });
+
+  const duplicate = JSON.parse(
+    msg('dup01', 'a1', '2026-07-27T13:20:00.000Z', 'assistant', {
+      provider: 'kimi-code',
+      model: 'k3-256k',
+      usage: usage(500, 100, 2000),
+    }),
+  );
+
+  writeFileSync(join(groupDir, fileName), [
+    JSON.stringify({ type: 'title', v: 1, title: '', updatedAt: '2026-07-27T13:19:57.093Z' }),
+    JSON.stringify({
+      type: 'session',
+      version: 3,
+      id: sessionId,
+      timestamp: '2026-07-27T13:19:57.093Z',
+      cwd: '/home/AI-gf',
+    }),
+    JSON.stringify({ type: 'model_change', id: 'mc01', parentId: null, timestamp: '2026-07-27T13:19:57.710Z', model: 'k3-256k' }),
+    msg('u1', null, '2026-07-27T13:20:00.000Z', 'user'),
+    msg('a1', 'u1', '2026-07-27T13:20:10.000Z', 'assistant', {
+      provider: 'kimi-code',
+      model: 'k3-256k',
+      usage: usage(1000, 200, 5000),
+    }),
+    msg('t1', 'a1', '2026-07-27T13:20:12.000Z', 'toolResult'),
+    JSON.stringify(duplicate),
+    // Same entry id replayed (compaction/rewrite) — must be deduplicated.
+    JSON.stringify(duplicate),
+    // Second half-hour bucket, no cache read.
+    msg('u2', 't1', '2026-07-27T13:45:00.000Z', 'user'),
+    msg('a2', 'u2', '2026-07-27T13:45:05.000Z', 'assistant', {
+      provider: 'kimi-code',
+      model: 'k3-256k',
+      usage: usage(300, 50, 0),
+    }),
+    'not json at all',
+  ].join('\n') + '\n');
+}
+
+test('parse reads omp assistant usage, dedups entries, and extracts sessions', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-omp-test-'));
+  const agentDir = join(root, 'agent');
+  const sessionsDir = join(agentDir, 'sessions');
+  writeSessionFixture(sessionsDir);
+
+  const prev = process.env.OMP_AGENT_DIR;
+  process.env.OMP_AGENT_DIR = agentDir;
+
+  try {
+    const result = await parse();
+
+    const buckets = result.buckets.filter((b) => b.source === 'omp');
+    assert.equal(buckets.length, 2);
+    for (const b of buckets) {
+      assert.equal(b.model, 'k3-256k');
+      assert.equal(b.project, 'AI-gf');
+    }
+
+    const byStart = new Map(buckets.map((b) => [b.bucketStart, b]));
+    const first = byStart.get('2026-07-27T13:00:00.000Z');
+    assert.ok(first, 'expected 13:00 bucket');
+    assert.equal(first.inputTokens, 1000 + 500);
+    assert.equal(first.outputTokens, 200 + 100);
+    assert.equal(first.cachedInputTokens, 5000 + 2000);
+
+    const second = byStart.get('2026-07-27T13:30:00.000Z');
+    assert.ok(second, 'expected 13:30 bucket');
+    assert.equal(second.inputTokens, 300);
+    assert.equal(second.outputTokens, 50);
+    assert.equal(second.cachedInputTokens, 0);
+
+    const sum = (key) => buckets.reduce((a, b) => a + (b[key] || 0), 0);
+    assert.equal(sum('inputTokens'), 1800);
+    assert.equal(sum('outputTokens'), 350);
+    assert.equal(sum('cachedInputTokens'), 7000);
+
+    assert.equal(result.sessions.length, 1);
+    const session = result.sessions[0];
+    assert.equal(session.source, 'omp');
+    assert.equal(session.project, 'AI-gf');
+    assert.equal(session.userMessageCount, 2);
+    assert.ok(session.messageCount >= 6);
+    assert.equal(session.firstMessageAt, '2026-07-27T13:20:00.000Z');
+    assert.equal(session.lastMessageAt, '2026-07-27T13:45:05.000Z');
+    assert.ok(session.sessionHash);
+  } finally {
+    if (prev !== undefined) {
+      process.env.OMP_AGENT_DIR = prev;
+    } else {
+      delete process.env.OMP_AGENT_DIR;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('parse returns empty result when omp agent dir is missing', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-omp-empty-'));
+  const prev = process.env.OMP_AGENT_DIR;
+  process.env.OMP_AGENT_DIR = join(root, 'does-not-exist');
+
+  try {
+    const result = await parse();
+    assert.deepEqual(result, { buckets: [], sessions: [] });
+  } finally {
+    if (prev !== undefined) {
+      process.env.OMP_AGENT_DIR = prev;
+    } else {
+      delete process.env.OMP_AGENT_DIR;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #41 (client side).

## What

Adds a parser for [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`, 20k+ stars), a popular fork of pi. omp stores sessions at `~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` — the format is identical to pi (same `message.usage = { input, output, cacheRead, cacheWrite }` on assistant messages), so this parser is a close adaptation of `pi-coding-agent.js`:

- `src/parsers/omp.js` — new parser; env override `OMP_AGENT_DIR` (mirrors `PI_CODING_AGENT_DIR`); reads only `*.jsonl`, ignores companion `*.bash.log` directories; dedup by entry id; project from `session` line `cwd` with encoded-dir fallback; source key `omp`
- `src/parsers/index.js` — registry entry
- `src/tools.js` — detection via `~/.omp/agent`
- `README.md` — Supported Tools row
- `test/omp.test.js` — synthesized temp-dir fixture (30-min bucketing, cacheRead sums, id dedup, companion-dir ignore, malformed-line skip, session extraction, missing-dir empty result)

## Verification

- `npm test`: **88/88 pass** (2 new)
- Validated against a real omp v17.1.5 session file (653 lines, private data, not committed): parser output matches ground truth exactly — 153 assistant usage records → 4 buckets; Σ input 193,945 / output 66,205 / cacheRead 17,548,999; 1 session (project from `cwd`, 9 user messages, duration 4,412 s)

## Maintainer action needed (server side)

As with #5 (antigravity), the new `omp` source needs to be added to the backend ingest `VALID_SOURCES` whitelist, and pricing registered for any new models. Also flagging the source-id choice: this PR uses **`omp`** (matches the binary name, short like `pi`); happy to rename to `oh-my-pi` if you prefer.

## Note on dedup with official pi

omp and official pi use separate roots (`~/.omp` vs `~/.pi`) and separate session ids, and omp sessions are only ever written by omp — so no cross-tool double counting.