### PR TITLE
chore: release v0.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibe-cafe/vibe-usage",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibe-cafe/vibe-usage",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "bin": {
         "vibe-usage": "bin/vibe-usage.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-cafe/vibe-usage",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Track your AI coding tool token usage and sync to vibecafe.ai",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- bump `@vibe-cafe/vibe-usage` from `0.10.4` to `0.10.5`
- keep `package.json` and `package-lock.json` aligned

This patch release packages the already-merged DimAgent, additional Codex home, and MiMoCode support. The corresponding backend source registrations for DimAgent and MiMoCode are already on `vibe-cafe/vibe-cafe` main.

## Validation

- `npm test` — 109/109 passing
- `npm pack --dry-run --json` — valid 0.10.5 tarball, 45 files
- `npm publish --dry-run --access public` — successful; actual publish intentionally not run

## Remaining manual step

After this PR is merged and CI is green, the maintainer will run the authenticated `npm publish --access public`.