### PR TITLE
feat: add WorkBuddy usage parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ vibe-usage/
 │   │   ├── kiro.js            # SQLite (via sqlite.js), JSONL fallback
 │   │   ├── hermes.js          # SQLite (via sqlite.js), multi-profile
 │   │   ├── trae-cli.js        # Trae CLI JSONL telemetry (not Trae IDE/Work)
+│   │   ├── workbuddy.js        # WorkBuddy JSONL, actual per-request model usage
 │   │   └── zcode.js           # SQLite (via sqlite.js), reads message table
 │   ├── pi-roots.js            # Pi/OMP default, profile, XDG, and override discovery
 │   ├── cline-roots.js         # Standalone + VSCode-host Cline discovery
@@ -148,7 +149,7 @@ node -e "import('./src/parsers/<tool-id>.js').then(m => m.parse()).then(r => con
 Test hooks (env vars honored at module load, set them before importing):
 - `VIBE_USAGE_STATE_DIR` / `VIBE_USAGE_CONFIG_DIR` — redirect `state.js` / `config.js` away from the real `~/.vibe-usage` (used by `test/state.test.js`, `test/reset.test.js`)
 - Codex cache controls: `VIBE_USAGE_CACHE_DIR` redirects cache writes, `VIBE_USAGE_CODEX_CACHE=0` disables the optimization, `VIBE_USAGE_CODEX_WORK_BUDGET_MS` overrides the non-interactive build budget, and `VIBE_USAGE_CODEX_AUDIT_INTERVAL_MS` / `VIBE_USAGE_CODEX_AUDIT_MAX_BYTES` override rolling-audit bounds
-- Per-parser fixtures: `CODEX_HOME`, `VIBE_USAGE_GROK_SESSIONS`, `VIBE_USAGE_KIMI_CODE_DIR`, `VIBE_USAGE_KIMI_DIR`, `VIBE_USAGE_TRAE_CLI_SESSIONS`, `VIBE_USAGE_KIRO_LEGACY_TOKENS`. The Kimi Code parser resolves its data root as `VIBE_USAGE_KIMI_CODE_DIR` → `KIMI_CODE_HOME` (matching the CLI) → `~/.kimi-code`, and always merges the legacy `~/.kimi` store instead of either/or (`kimi migrate` drops usage records, so no double-count)
+- Per-parser fixtures: `CODEX_HOME`, `VIBE_USAGE_GROK_SESSIONS`, `VIBE_USAGE_KIMI_CODE_DIR`, `VIBE_USAGE_KIMI_DIR`, `VIBE_USAGE_TRAE_CLI_SESSIONS`, `VIBE_USAGE_WORKBUDDY_DIRS`, `VIBE_USAGE_KIRO_LEGACY_TOKENS`. The Kimi Code parser resolves its data root as `VIBE_USAGE_KIMI_CODE_DIR` → `KIMI_CODE_HOME` (matching the CLI) → `~/.kimi-code`, and always merges the legacy `~/.kimi` store instead of either/or (`kimi migrate` drops usage records, so no double-count)
 - Claude fixtures: `VIBE_USAGE_CLAUDE_DIRS` replaces normal Claude root discovery with a `path.delimiter`-separated root list; `VIBE_USAGE_CLAUDE_DESKTOP_DIRS` overrides only the Claude Desktop user-data roots. The production parser scans `~/.claude`, `$CLAUDE_CONFIG_DIR`, data-bearing `~/.claude-*` profiles, and the per-session `.claude` roots created below Claude Desktop's `local-agent-mode-sessions`. Desktop Code already writes to the normal Claude Code root, while Cowork uses the private roots. Both remain source `claude-code`. The parser streams each JSONL file to its captured size, keeps the most complete duplicate session/UUID, and returns `skipped` with warnings after any read failure so incremental state is not pruned.
 - Pi-family/Cline/OpenClaw fixtures: `VIBE_USAGE_PI_SESSION_DIRS`, `VIBE_USAGE_OMP_SESSION_DIRS`, `VIBE_USAGE_CLINE_DIRS`, and `VIBE_USAGE_OPENCLAW_DIRS` replace normal discovery with `path.delimiter`-separated roots.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | Trae CLI | macOS: `~/Library/Caches/trae-cli/sessions/`; Windows: `%LOCALAPPDATA%/trae-cli/cache/sessions/`; Linux: `~/.cache/trae-cli/sessions/` (CLI telemetry only; Trae IDE/Trae Work chats are not supported) |
 | Antigravity | App 2.0 `~/.gemini/antigravity/conversations/*.db` and `agy` CLI `~/.gemini/antigravity-cli/conversations/*.db` are parsed offline (tokens, real model display name, project, sessions); legacy App `.pb` history falls back to Connect RPC while the language server is running |
 | ZCode | `~/.zcode/cli/db/db.sqlite` (SQLite; reads the `message` table for per-message tokens, model, and project `cwd`/`root`, joined to `session.directory`) |
+| WorkBuddy | macOS WorkBuddy 5.3.11+: `~/.workbuddy/projects/**/*.jsonl` (or `VIBE_USAGE_WORKBUDDY_DIRS` for relocated/test roots). Uses completed assistant requests only and attributes each bucket to the actual request model (`providerData.requestModelId`), so a task using Auto can appear under multiple routed models. Cache reads and reasoning tokens are split from inclusive input/output totals. SQLite context-window occupancy and web login/API data are never used. |
 
 ## How It Works
 

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -23,6 +23,7 @@ import { parse as parseMimocode } from './mimocode.js';
 import { parse as parsePiCodingAgent } from './pi-coding-agent.js';
 import { parse as parseZcode } from './zcode.js';
 import { parse as parseTraeCli } from './trae-cli.js';
+import { parse as parseWorkbuddy } from './workbuddy.js';
 
 export const parsers = {
   'claude-code': parseClaudeCode,
@@ -49,6 +50,7 @@ export const parsers = {
   'cline': parseCline,
   'roo-code': parseRooCode,
   'zcode': parseZcode,
+  'workbuddy': parseWorkbuddy,
 };
 
 

--- a/src/parsers/workbuddy.js
+++ b/src/parsers/workbuddy.js
@@ -195,6 +195,7 @@ export async function parse() {
   const events = [];
   const ctx = { skipped: false, warnings: [] };
   const seenIds = new Set();
+  const seenEventIds = new Set();
 
   for (const configuredRoot of findWorkbuddyDataDirs()) {
     const projectsDir = basename(configuredRoot) === 'projects' ? configuredRoot : join(configuredRoot, 'projects');
@@ -215,7 +216,11 @@ export async function parse() {
       await readJsonl(filePath, size, (record) => {
         const project = projectFromRecord(record, fileProject);
         const event = timingEventFor(record, record.sessionId ?? record.session_id ?? fileSessionId, project);
-        if (event) events.push(event);
+        const eventId = typeof record.id === 'string' && record.id ? record.id : null;
+        if (event && (!eventId || !seenEventIds.has(eventId))) {
+          events.push(event);
+          if (eventId) seenEventIds.add(eventId);
+        }
         if (!isCompletedAssistant(record)) return;
         if (typeof record.id !== 'string' || !record.id || seenIds.has(record.id)) return;
         const usage = usageFor(record);

--- a/src/parsers/workbuddy.js
+++ b/src/parsers/workbuddy.js
@@ -1,0 +1,218 @@
+import { createReadStream, readdirSync, statSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { basename, join, relative, sep } from 'node:path';
+import { findWorkbuddyDataDirs } from '../workbuddy-roots.js';
+import { aggregateToBuckets } from './index.js';
+
+const SOURCE = 'workbuddy';
+
+function finite(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+function dateFrom(value) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value < 1e12 ? value * 1000 : value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function projectFromFile(filePath, projectsDir) {
+  const rel = relative(projectsDir, filePath);
+  const first = rel.split(sep).filter(Boolean)[0];
+  return first ? basename(first) : 'unknown';
+}
+
+function projectFromRecord(record, fallback) {
+  const cwd = typeof record.cwd === 'string' ? record.cwd.trim() : '';
+  if (!cwd) return fallback;
+  const project = basename(cwd.replace(/[\\/]+$/, ''));
+  return project || fallback;
+}
+
+function findJsonlFiles(dir, ctx) {
+  let children;
+  try {
+    children = readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    ctx.skipped = true;
+    ctx.warnings.push('workbuddy: cannot read a data directory');
+    return [];
+  }
+
+  const files = [];
+  for (const child of children) {
+    const fullPath = join(dir, child.name);
+    if (child.isDirectory()) files.push(...findJsonlFiles(fullPath, ctx));
+    else if (child.isFile() && child.name.endsWith('.jsonl')) files.push(fullPath);
+  }
+  return files;
+}
+
+async function readJsonl(filePath, size, onRecord, ctx) {
+  if (size <= 0) return;
+  let stream;
+  try {
+    stream = createReadStream(filePath, {
+      encoding: 'utf8',
+      start: 0,
+      end: size - 1,
+    });
+  } catch (error) {
+    ctx.skipped = true;
+    ctx.warnings.push('workbuddy: cannot read a session file');
+    return;
+  }
+
+  let streamError = null;
+  stream.on('error', (error) => { streamError = error; });
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (record && typeof record === 'object') onRecord(record);
+    }
+    if (streamError) throw streamError;
+  } catch (error) {
+    ctx.skipped = true;
+    ctx.warnings.push('workbuddy: cannot read a session file');
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+}
+
+function isCompletedAssistant(record) {
+  const message = record.message;
+  if (!message || typeof message !== 'object') return false;
+  if (record.type !== 'message') return false;
+  const role = record.role ?? message.role;
+  if (role !== 'assistant' && role !== 'assistant_message') return false;
+  const status = String(record.status ?? message.status ?? record.state ?? message.state ?? '').toLowerCase();
+  return status === 'completed' || status === 'complete' || status === 'success';
+}
+
+function modelFor(record) {
+  const providerData = record.providerData;
+  if (providerData && typeof providerData.requestModelId === 'string' && providerData.requestModelId.trim()) {
+    return providerData.requestModelId.trim();
+  }
+  for (const value of [record.requestModelName, providerData?.requestModelName, providerData?.model]) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return 'unknown';
+}
+
+function usageFor(record) {
+  const providerData = record.providerData && typeof record.providerData === 'object'
+    ? record.providerData
+    : {};
+  const primary = providerData.usage && typeof providerData.usage === 'object'
+    ? providerData.usage
+    : record.message?.usage && typeof record.message.usage === 'object'
+      ? record.message.usage
+      : null;
+  const raw = providerData.rawUsage && typeof providerData.rawUsage === 'object'
+    ? providerData.rawUsage
+    : null;
+  if (!primary && !raw) return null;
+
+  const firstDetailValue = (details, ...keys) => {
+    const values = Array.isArray(details) ? details : [details];
+    for (const detail of values) {
+      if (!detail || typeof detail !== 'object') continue;
+      for (const key of keys) {
+        if (detail[key] != null) return finite(detail[key]);
+      }
+    }
+    return 0;
+  };
+  const inputDetails = primary?.input_details ?? primary?.inputDetails;
+  const outputDetails = primary?.output_details ?? primary?.outputDetails;
+  const cached = firstDetailValue(inputDetails, 'cached_tokens', 'cachedTokens')
+    || finite(primary?.cache_read_input_tokens ?? primary?.cacheReadInputTokens ?? raw?.prompt_cache_hit_tokens ?? raw?.cache_read_input_tokens);
+  const reasoning = firstDetailValue(outputDetails, 'reasoning_tokens', 'reasoningTokens')
+    || finite(primary?.completion_thinking_tokens ?? primary?.reasoning_tokens ?? primary?.reasoningTokens ?? raw?.completion_thinking_tokens);
+  const totalInput = finite(primary?.inputTokens ?? primary?.input_tokens ?? raw?.prompt_tokens);
+  const totalOutput = finite(primary?.outputTokens ?? primary?.output_tokens ?? raw?.completion_tokens);
+  const rawMiss = finite(raw?.prompt_cache_miss_tokens);
+  // `prompt_cache_miss_tokens` is already exclusive of cache reads. The
+  // aggregate `inputTokens` field is inclusive, so only that fallback needs
+  // cache subtraction.
+  const inputTokens = rawMiss > 0 ? rawMiss : Math.max(0, totalInput - cached);
+  const outputTokens = Math.max(0, totalOutput - reasoning);
+  const totalTokens = finite(primary?.totalTokens ?? primary?.total_tokens ?? raw?.total_tokens);
+  if (inputTokens + outputTokens + cached + reasoning === 0) return null;
+  return {
+    inputTokens,
+    outputTokens,
+    cachedInputTokens: cached,
+    reasoningOutputTokens: reasoning,
+    totalTokens,
+  };
+}
+
+function timestampFor(record) {
+  return dateFrom(record.completedAt ?? record.completed_at ?? record.timestamp ?? record.createdAt ?? record.created_at ?? record.message?.createdAt);
+}
+
+export async function parse() {
+  const entries = [];
+  const ctx = { skipped: false, warnings: [] };
+  const seenIds = new Set();
+
+  for (const configuredRoot of findWorkbuddyDataDirs()) {
+    const projectsDir = basename(configuredRoot) === 'projects' ? configuredRoot : join(configuredRoot, 'projects');
+    const files = findJsonlFiles(projectsDir, ctx);
+    for (const filePath of files) {
+      let size;
+      try {
+        size = statSync(filePath).size;
+      } catch (error) {
+        ctx.skipped = true;
+        ctx.warnings.push('workbuddy: cannot stat a session file');
+        continue;
+      }
+      const fileProject = projectFromFile(filePath, projectsDir);
+      await readJsonl(filePath, size, (record) => {
+        if (!isCompletedAssistant(record)) return;
+        if (typeof record.id !== 'string' || !record.id || seenIds.has(record.id)) return;
+        const usage = usageFor(record);
+        const timestamp = timestampFor(record);
+        if (!usage || !timestamp) return;
+        seenIds.add(record.id);
+        entries.push({
+          source: SOURCE,
+          model: modelFor(record),
+          project: projectFromRecord(record, fileProject),
+          timestamp,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cachedInputTokens: usage.cachedInputTokens,
+          reasoningOutputTokens: usage.reasoningOutputTokens,
+        });
+      }, ctx);
+    }
+  }
+
+  return {
+    buckets: aggregateToBuckets(entries),
+    sessions: [],
+    ...(ctx.skipped ? { skipped: true } : {}),
+    ...(ctx.warnings.length > 0 ? { warnings: ctx.warnings } : {}),
+  };
+}

--- a/src/parsers/workbuddy.js
+++ b/src/parsers/workbuddy.js
@@ -2,7 +2,7 @@ import { createReadStream, readdirSync, statSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { basename, join, relative, sep } from 'node:path';
 import { findWorkbuddyDataDirs } from '../workbuddy-roots.js';
-import { aggregateToBuckets } from './index.js';
+import { aggregateToBuckets, extractSessions } from './index.js';
 
 const SOURCE = 'workbuddy';
 
@@ -170,8 +170,29 @@ function timestampFor(record) {
   return dateFrom(record.completedAt ?? record.completed_at ?? record.timestamp ?? record.createdAt ?? record.created_at ?? record.message?.createdAt);
 }
 
+function timingEventFor(record, sessionId, project) {
+  if (record.type !== 'message') return null;
+  const role = record.role ?? record.message?.role;
+  if (role !== 'user' && role !== 'assistant' && role !== 'assistant_message') return null;
+  const timestamp = timestampFor(record);
+  if (!timestamp) return null;
+  return {
+    sessionId,
+    source: SOURCE,
+    project,
+    timestamp,
+    role: role === 'user' ? 'user' : 'assistant',
+  };
+}
+
+function sessionEventsWithPrompts(events) {
+  const hasUserPrompt = new Set(events.filter(event => event.role === 'user').map(event => event.sessionId));
+  return events.filter(event => hasUserPrompt.has(event.sessionId));
+}
+
 export async function parse() {
   const entries = [];
+  const events = [];
   const ctx = { skipped: false, warnings: [] };
   const seenIds = new Set();
 
@@ -188,7 +209,13 @@ export async function parse() {
         continue;
       }
       const fileProject = projectFromFile(filePath, projectsDir);
+      // Only this derived relative identifier reaches extractSessions(), which
+      // hashes it before upload. Never retain or upload the absolute file path.
+      const fileSessionId = `workbuddy:${relative(projectsDir, filePath)}`;
       await readJsonl(filePath, size, (record) => {
+        const project = projectFromRecord(record, fileProject);
+        const event = timingEventFor(record, record.sessionId ?? record.session_id ?? fileSessionId, project);
+        if (event) events.push(event);
         if (!isCompletedAssistant(record)) return;
         if (typeof record.id !== 'string' || !record.id || seenIds.has(record.id)) return;
         const usage = usageFor(record);
@@ -198,7 +225,7 @@ export async function parse() {
         entries.push({
           source: SOURCE,
           model: modelFor(record),
-          project: projectFromRecord(record, fileProject),
+          project,
           timestamp,
           inputTokens: usage.inputTokens,
           outputTokens: usage.outputTokens,
@@ -211,7 +238,7 @@ export async function parse() {
 
   return {
     buckets: aggregateToBuckets(entries),
-    sessions: [],
+    sessions: extractSessions(sessionEventsWithPrompts(events)),
     ...(ctx.skipped ? { skipped: true } : {}),
     ...(ctx.warnings.length > 0 ? { warnings: ctx.warnings } : {}),
   };

--- a/src/tools.js
+++ b/src/tools.js
@@ -6,6 +6,7 @@ import { codexSessionDirs, resolveCodexHomes } from './codex-roots.js';
 import { findClineDataDirs } from './cline-roots.js';
 import { findCraftDataDirs } from './craft-roots.js';
 import { findOmpDataDirs, findPiDataDirs } from './pi-roots.js';
+import { findWorkbuddyDataDirs } from './workbuddy-roots.js';
 
 function getCursorStateDbPath() {
   const rel = join('User', 'globalStorage', 'state.vscdb');
@@ -307,6 +308,12 @@ export const TOOLS = [
     id: 'roo-code',
     dataDir: join(homedir(), 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline'),
     detectDataDirs: findRooCodeDataDirs,
+  },
+  {
+    name: 'WorkBuddy',
+    id: 'workbuddy',
+    dataDir: join(homedir(), '.workbuddy', 'projects'),
+    detectDataDirs: () => findWorkbuddyDataDirs().filter(existsSync),
   },
   {
     name: 'ZCode',

--- a/src/workbuddy-roots.js
+++ b/src/workbuddy-roots.js
@@ -1,0 +1,40 @@
+import { delimiter, join } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * WorkBuddy (~/.workbuddy) is a local-only AI coding tool. It stores per-project
+ * session history as line-delimited JSON files under
+ *   $WORKBUDDY_HOME/projects/<project>/<session>.jsonl
+ * where $WORKBUDDY_HOME defaults to ~/.workbuddy.
+ *
+ * Test/relocation hook: set VIBE_USAGE_WORKBUDDY_DIRS to a path.delimiter-separated
+ * list of roots. When unset, only the default ~/.workbuddy is scanned — the
+ * user's actual machine state must never be silently absorbed from extra
+ * locations.
+ */
+
+export function getWorkbuddyHome() {
+  return join(homedir(), '.workbuddy');
+}
+
+export function getDefaultWorkbuddyProjectsDir() {
+  return join(getWorkbuddyHome(), 'projects');
+}
+
+/**
+ * Return every WorkBuddy data root visible to this process. Each entry is a
+ * `projects` directory (or the configured root itself when the override names
+ * the projects directory directly). Empty / non-existent roots are filtered
+ * out so callers can iterate without extra checks.
+ */
+export function findWorkbuddyDataDirs() {
+  const override = process.env.VIBE_USAGE_WORKBUDDY_DIRS?.trim();
+  if (override) {
+    return override
+      .split(delimiter)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  const fallback = getDefaultWorkbuddyProjectsDir();
+  return [fallback];
+}

--- a/test/workbuddy-e2e.test.js
+++ b/test/workbuddy-e2e.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import { promisify } from 'node:util';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+async function withServer(handler, run) {
+  const server = createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address();
+  try {
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+function fixtureRecord(id, model, cwd) {
+  return {
+    id,
+    timestamp: '2026-08-10T00:50:30.000Z',
+    type: 'message', role: 'assistant', status: 'completed', cwd,
+    content: [{ type: 'text', text: 'PRIVATE_WORKBUDDY_PROMPT' }],
+    message: { usage: { inputTokens: 100, outputTokens: 20 } },
+    providerData: { requestModelId: model, usage: { inputTokens: 100, outputTokens: 20 } },
+  };
+}
+
+test('WorkBuddy E2E sync uploads actual routed model buckets once and no conversation data', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-e2e-'));
+  const projects = join(root, 'workbuddy', 'projects', 'encoded');
+  const configDir = join(root, 'config');
+  const stateDir = join(root, 'state');
+  const homeDir = join(root, 'home');
+  mkdirSync(projects, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+  writeFileSync(join(projects, 'session.jsonl'), [
+    JSON.stringify(fixtureRecord('request-a', 'actual-model-a', '/private/workspace/a')),
+    JSON.stringify(fixtureRecord('request-b', 'actual-model-b', '/private/workspace/b')),
+  ].join('\n') + '\n');
+
+  const received = [];
+  try {
+    await withServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/api/usage/settings') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ uploadProject: true }));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/api/usage/ingest') {
+        const chunks = [];
+        req.on('data', chunk => chunks.push(chunk));
+        req.on('end', () => {
+          received.push(JSON.parse(gunzipSync(Buffer.concat(chunks)).toString('utf8')));
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ingested: received.at(-1).buckets.length }));
+        });
+        return;
+      }
+      res.writeHead(404).end();
+    }, async apiUrl => {
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+        apiKey: 'vbu_e2e_test', apiUrl, hostname: 'workbuddy-e2e',
+      }));
+      const env = {
+        ...process.env,
+        HOME: homeDir,
+        VIBE_USAGE_CONFIG_DIR: configDir,
+        VIBE_USAGE_STATE_DIR: stateDir,
+        VIBE_USAGE_WORKBUDDY_DIRS: join(root, 'workbuddy'),
+      };
+      const command = "import { runSync } from './src/sync.js'; await runSync({ throws: true, quiet: true });";
+      await execFileAsync(process.execPath, ['--input-type=module', '-e', command], {
+        cwd: process.cwd(), env,
+      });
+      await execFileAsync(process.execPath, ['--input-type=module', '-e', command], {
+        cwd: process.cwd(), env,
+      });
+    });
+
+    assert.equal(received.length, 1, 'the unchanged second sync must not POST');
+    assert.equal(received[0].buckets.length, 2);
+    assert.deepEqual(new Set(received[0].buckets.map(bucket => bucket.model)), new Set([
+      'actual-model-a', 'actual-model-b',
+    ]));
+    assert.equal(received[0].buckets.every(bucket => bucket.source === 'workbuddy'), true);
+    const payload = JSON.stringify(received[0]);
+    assert.equal(payload.includes('PRIVATE_WORKBUDDY_PROMPT'), false);
+    assert.equal(payload.includes('/private/workspace'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/workbuddy-e2e.test.js
+++ b/test/workbuddy-e2e.test.js
@@ -35,6 +35,18 @@ function fixtureRecord(id, model, cwd) {
   };
 }
 
+function userFixtureRecord(sessionId, cwd) {
+  return {
+    sessionId,
+    timestamp: '2026-08-10T00:50:00.000Z',
+    type: 'message',
+    role: 'user',
+    cwd,
+    content: [{ type: 'text', text: 'PRIVATE_WORKBUDDY_PROMPT' }],
+    message: { role: 'user' },
+  };
+}
+
 test('WorkBuddy E2E sync uploads actual routed model buckets once and no conversation data', async () => {
   const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-e2e-'));
   const projects = join(root, 'workbuddy', 'projects', 'encoded');
@@ -44,8 +56,9 @@ test('WorkBuddy E2E sync uploads actual routed model buckets once and no convers
   mkdirSync(projects, { recursive: true });
   mkdirSync(homeDir, { recursive: true });
   writeFileSync(join(projects, 'session.jsonl'), [
-    JSON.stringify(fixtureRecord('request-a', 'actual-model-a', '/private/workspace/a')),
-    JSON.stringify(fixtureRecord('request-b', 'actual-model-b', '/private/workspace/b')),
+    JSON.stringify(userFixtureRecord('private-session-id', '/private/workspace/a')),
+    JSON.stringify({ ...fixtureRecord('request-a', 'actual-model-a', '/private/workspace/a'), sessionId: 'private-session-id' }),
+    JSON.stringify({ ...fixtureRecord('request-b', 'actual-model-b', '/private/workspace/b'), sessionId: 'private-session-id' }),
   ].join('\n') + '\n');
 
   const received = [];
@@ -72,13 +85,22 @@ test('WorkBuddy E2E sync uploads actual routed model buckets once and no convers
       writeFileSync(join(configDir, 'config.json'), JSON.stringify({
         apiKey: 'vbu_e2e_test', apiUrl, hostname: 'workbuddy-e2e',
       }));
-      const env = {
-        ...process.env,
+      // Keep the child process hermetic: host-level parser overrides such as
+      // CODEX_HOME must not add unrelated uploads to this assertion.
+      const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => (
+        !key.startsWith('VIBE_USAGE_')
+        && ![
+          'CODEX_HOME', 'CLAUDE_CONFIG_DIR', 'GROK_HOME', 'KIMI_CODE_HOME',
+          'MIMOCODE_HOME', 'MIMOCODE_DB', 'DIMCODE_HOME', 'XDG_CONFIG_HOME',
+          'XDG_DATA_HOME', 'XDG_CACHE_HOME', 'APPDATA', 'LOCALAPPDATA',
+        ].includes(key)
+      )));
+      Object.assign(env, {
         HOME: homeDir,
         VIBE_USAGE_CONFIG_DIR: configDir,
         VIBE_USAGE_STATE_DIR: stateDir,
         VIBE_USAGE_WORKBUDDY_DIRS: join(root, 'workbuddy'),
-      };
+      });
       const command = "import { runSync } from './src/sync.js'; await runSync({ throws: true, quiet: true });";
       await execFileAsync(process.execPath, ['--input-type=module', '-e', command], {
         cwd: process.cwd(), env,
@@ -94,9 +116,11 @@ test('WorkBuddy E2E sync uploads actual routed model buckets once and no convers
       'actual-model-a', 'actual-model-b',
     ]));
     assert.equal(received[0].buckets.every(bucket => bucket.source === 'workbuddy'), true);
+    assert.equal(received[0].sessions.length, 1);
     const payload = JSON.stringify(received[0]);
     assert.equal(payload.includes('PRIVATE_WORKBUDDY_PROMPT'), false);
     assert.equal(payload.includes('/private/workspace'), false);
+    assert.equal(payload.includes('private-session-id'), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/workbuddy.test.js
+++ b/test/workbuddy.test.js
@@ -51,9 +51,10 @@ function writeFixture(root, lines, project = 'demo-project') {
   writeFileSync(join(projects, 'conversation.jsonl'), `${lines.join('\n')}\n`, 'utf8');
 }
 
-function userRecord({ sessionId, timestamp, cwd, prompt }) {
+function userRecord({ id, sessionId, timestamp, cwd, prompt }) {
   return {
     type: 'message',
+    id,
     sessionId,
     timestamp,
     cwd,
@@ -146,7 +147,7 @@ test('records only de-identified WorkBuddy session metadata', async () => {
     const usage = { inputTokens: 10, outputTokens: 2 };
     writeFixture(root, [
       JSON.stringify(userRecord({
-        sessionId, cwd, prompt: 'confidential prompt', timestamp: '2026-08-11T10:00:00.000Z',
+        id: 'prompt', sessionId, cwd, prompt: 'confidential prompt', timestamp: '2026-08-11T10:00:00.000Z',
       })),
       JSON.stringify({
         ...assistantRecord({
@@ -164,6 +165,29 @@ test('records only de-identified WorkBuddy session metadata', async () => {
     assert.equal(serialized.includes(cwd), false);
     assert.equal(serialized.includes(sessionId), false);
     assert.equal(serialized.includes('confidential prompt'), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('deduplicates timing records by stable record id', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-event-dedup-'));
+  try {
+    const sessionId = 'session-with-copied-records';
+    const cwd = '/private/workspace';
+    const usage = { inputTokens: 10, outputTokens: 2 };
+    const prompt = userRecord({
+      id: 'copied-user', sessionId, cwd, timestamp: '2026-08-11T10:00:00.000Z',
+    });
+    const reply = {
+      ...assistantRecord({
+        id: 'copied-assistant', modelId: 'model-a', usage, cwd, timestamp: '2026-08-11T10:00:05.000Z',
+      }),
+      sessionId,
+    };
+    writeFixture(root, [JSON.stringify(prompt), JSON.stringify(reply), JSON.stringify(prompt), JSON.stringify(reply)]);
+    const result = await withRoots([root], () => parse());
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].messageCount, 2);
+    assert.equal(result.sessions[0].userMessageCount, 1);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/test/workbuddy.test.js
+++ b/test/workbuddy.test.js
@@ -1,118 +1,178 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { parse } from '../src/parsers/workbuddy.js';
-import { parsers } from '../src/parsers/index.js';
-import { TOOLS } from '../src/tools.js';
 import { findWorkbuddyDataDirs } from '../src/workbuddy-roots.js';
 
-function completedRecord({ id, model, timestamp, usage, rawUsage, cwd = '/private/repo/actual-project' }) {
+function assistantRecord({
+  id,
+  modelId,
+  modelName,
+  status = 'completed',
+  timestamp = '2026-08-11T10:05:00.000Z',
+  usage,
+  rawUsage,
+  prompt,
+  cwd,
+}) {
   return {
-    id,
-    timestamp,
     type: 'message',
-    role: 'assistant',
-    status: 'completed',
+    id,
+    status,
+    timestamp,
     cwd,
-    content: [{ type: 'text', text: 'PROMPT_AND_RESPONSE_MUST_NOT_LEAK' }],
-    message: { usage },
+    prompt,
+    message: { role: 'assistant', usage },
     providerData: {
-      requestModelId: model,
+      requestModelId: modelId,
+      requestModelName: modelName,
       usage,
-      ...(rawUsage ? { rawUsage } : {}),
-      conversationRequestId: 'not-a-dedup-key',
+      rawUsage,
     },
   };
 }
 
-test('WorkBuddy is registered and honors its fixture root override', () => {
-  const prior = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
-  process.env.VIBE_USAGE_WORKBUDDY_DIRS = '/tmp/workbuddy-a:/tmp/workbuddy-b';
+async function withRoots(roots, fn) {
+  const previous = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+  process.env.VIBE_USAGE_WORKBUDDY_DIRS = roots.join(delimiter);
   try {
-    assert.equal(typeof parsers.workbuddy, 'function');
-    assert.equal(TOOLS.find(tool => tool.id === 'workbuddy')?.name, 'WorkBuddy');
-    assert.deepEqual(findWorkbuddyDataDirs(), ['/tmp/workbuddy-a', '/tmp/workbuddy-b']);
+    return await fn();
   } finally {
-    if (prior === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
-    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = prior;
+    if (previous === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = previous;
   }
+}
+
+function writeFixture(root, lines, project = 'demo-project') {
+  const projects = join(root, 'projects', project);
+  mkdirSync(projects, { recursive: true });
+  writeFileSync(join(projects, 'conversation.jsonl'), `${lines.join('\n')}\n`, 'utf8');
+}
+
+function userRecord({ sessionId, timestamp, cwd, prompt }) {
+  return {
+    type: 'message',
+    sessionId,
+    timestamp,
+    cwd,
+    prompt,
+    message: { role: 'user' },
+  };
+}
+
+const sampleUsage = {
+  inputTokens: 34824,
+  outputTokens: 31,
+  totalTokens: 34855,
+  input_details: { cached_tokens: 7488 },
+  output_details: { reasoning_tokens: 27 },
+};
+
+const sampleRawUsage = {
+  prompt_cache_miss_tokens: 27336,
+  completion_thinking_tokens: 27,
+};
+
+test('maps WorkBuddy 5.3.11 provider usage into exclusive token fields', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-mapping-'));
+  try {
+    writeFixture(root, [JSON.stringify(assistantRecord({
+      id: 'request-1', modelId: 'minimax-m2', usage: sampleUsage, rawUsage: sampleRawUsage,
+    }))]);
+    const result = await withRoots([root], () => parse());
+    assert.deepEqual(result.buckets[0], {
+      source: 'workbuddy', model: 'minimax-m2', project: 'demo-project',
+      bucketStart: '2026-08-11T10:00:00.000Z', inputTokens: 27336,
+      outputTokens: 4, cachedInputTokens: 7488, reasoningOutputTokens: 27,
+      totalTokens: 27367,
+    });
+    assert.deepEqual(result.sessions, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('WorkBuddy splits inclusive cache/reasoning totals and retains actual routed models', async () => {
-  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-'));
-  const firstProject = join(root, 'projects', 'encoded-project');
-  const copiedProject = join(root, 'projects', 'copied-project');
-  mkdirSync(firstProject, { recursive: true });
-  mkdirSync(copiedProject, { recursive: true });
-  const timestamp = '2026-08-10T00:50:30.000Z';
-  const hy3 = completedRecord({
-    id: 'request-hy3',
-    model: 'hy3',
-    timestamp,
-    usage: {
-      inputTokens: 34824,
-      outputTokens: 31,
-      totalTokens: 34855,
-      inputTokensDetails: [{ cached_tokens: 7488 }],
-      outputTokensDetails: [{ reasoning_tokens: 27 }],
-    },
-    rawUsage: {
-      prompt_tokens: 34824,
-      prompt_cache_hit_tokens: 7488,
-      prompt_cache_miss_tokens: 27336,
-      completion_tokens: 31,
-      completion_thinking_tokens: 27,
-      total_tokens: 34855,
-    },
-  });
-  const autoRouted = completedRecord({
-    id: 'request-auto-routed',
-    model: 'model-routed-by-auto',
-    timestamp,
-    usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 40 },
-    cwd: '/private/repo/another-project',
-  });
-  const pending = { ...completedRecord({
-    id: 'request-pending', model: 'must-not-count', timestamp,
-    usage: { inputTokens: 100, outputTokens: 20 },
-  }), status: 'pending' };
-  writeFileSync(join(firstProject, 'session-a.jsonl'), [
-    JSON.stringify(hy3),
-    JSON.stringify(autoRouted),
-    JSON.stringify(pending),
-    '{malformed',
-  ].join('\n') + '\n');
-  // WorkBuddy copies can occur between roots/projects. A top-level record id
-  // remains the canonical request identity, unlike conversationRequestId.
-  writeFileSync(join(copiedProject, 'session-copy.jsonl'), JSON.stringify(hy3) + '\n');
-
-  const prior = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
-  process.env.VIBE_USAGE_WORKBUDDY_DIRS = root;
+test('splits Auto sessions by request model id', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-models-'));
   try {
-    const result = await parse();
-    assert.equal(result.sessions.length, 0);
-    assert.equal(result.buckets.length, 2);
-    const byModel = Object.fromEntries(result.buckets.map(bucket => [bucket.model, bucket]));
-    assert.deepEqual(byModel.hy3, {
-      source: 'workbuddy', model: 'hy3', project: 'actual-project',
-      bucketStart: '2026-08-10T00:30:00.000Z',
-      inputTokens: 27336, outputTokens: 4, cachedInputTokens: 7488,
-      reasoningOutputTokens: 27, totalTokens: 27367,
+    const usage = { inputTokens: 10, outputTokens: 2, totalTokens: 12 };
+    writeFixture(root, [
+      JSON.stringify(assistantRecord({ id: 'a', modelId: 'model-a', modelName: 'Auto', usage })),
+      JSON.stringify(assistantRecord({ id: 'b', modelId: 'model-b', modelName: 'Auto', usage, timestamp: '2026-08-11T10:06:00.000Z' })),
+    ]);
+    const result = await withRoots([root], () => parse());
+    assert.deepEqual(result.buckets.map(({ model, inputTokens, outputTokens }) => ({ model, inputTokens, outputTokens })), [
+      { model: 'model-a', inputTokens: 10, outputTokens: 2 },
+      { model: 'model-b', inputTokens: 10, outputTokens: 2 },
+    ]);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('deduplicates repeated top-level record ids', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-dedup-'));
+  try {
+    const usage = { inputTokens: 10, outputTokens: 2, totalTokens: 12 };
+    const record = JSON.stringify(assistantRecord({ id: 'same', modelId: 'model-a', usage }));
+    writeFixture(root, [record, record]);
+    const result = await withRoots([root], () => parse());
+    assert.equal(result.buckets[0].inputTokens, 10);
+    assert.equal(result.buckets[0].outputTokens, 2);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('counts completed assistant messages, skips malformed lines, and preserves privacy', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-status-'));
+  try {
+    const usage = { inputTokens: 10, outputTokens: 2, totalTokens: 12 };
+    const pending = assistantRecord({ id: 'pending', modelId: 'model-a', usage, status: 'pending' });
+    const complete = assistantRecord({
+      id: 'complete', modelId: 'model-a', usage,
+      prompt: 'super secret prompt', cwd: '/Users/private/secret-project',
     });
-    assert.deepEqual(byModel['model-routed-by-auto'], {
-      source: 'workbuddy', model: 'model-routed-by-auto', project: 'another-project',
-      bucketStart: '2026-08-10T00:30:00.000Z',
-      inputTokens: 60, outputTokens: 20, cachedInputTokens: 40,
-      reasoningOutputTokens: 0, totalTokens: 80,
-    });
+    writeFixture(root, [JSON.stringify(pending), '{malformed', JSON.stringify(complete)]);
+    const result = await withRoots([root], () => parse());
+    assert.equal(result.buckets[0].inputTokens, 10);
     const serialized = JSON.stringify(result);
-    assert.equal(serialized.includes('PROMPT_AND_RESPONSE_MUST_NOT_LEAK'), false);
-    assert.equal(serialized.includes('/private/repo'), false);
-  } finally {
-    if (prior === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
-    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = prior;
-    rmSync(root, { recursive: true, force: true });
+    assert.equal(serialized.includes('super secret prompt'), false);
+    assert.equal(serialized.includes('/Users/private/secret-project'), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('records only de-identified WorkBuddy session metadata', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-sessions-'));
+  try {
+    const cwd = '/Users/private/absolute-workspace';
+    const sessionId = 'private-workbuddy-session-id';
+    const usage = { inputTokens: 10, outputTokens: 2 };
+    writeFixture(root, [
+      JSON.stringify(userRecord({
+        sessionId, cwd, prompt: 'confidential prompt', timestamp: '2026-08-11T10:00:00.000Z',
+      })),
+      JSON.stringify({
+        ...assistantRecord({
+          id: 'reply', modelId: 'model-a', usage, cwd, timestamp: '2026-08-11T10:00:05.000Z',
+        }),
+        sessionId,
+      }),
+    ]);
+    const result = await withRoots([root], () => parse());
+    assert.equal(result.sessions.length, 1);
+    assert.equal(result.sessions[0].project, 'absolute-workspace');
+    assert.equal(result.sessions[0].messageCount, 2);
+    assert.equal(result.sessions[0].userMessageCount, 1);
+    const serialized = JSON.stringify(result);
+    assert.equal(serialized.includes(cwd), false);
+    assert.equal(serialized.includes(sessionId), false);
+    assert.equal(serialized.includes('confidential prompt'), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('honors path.delimiter-separated roots override', () => {
+  const previous = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+  process.env.VIBE_USAGE_WORKBUDDY_DIRS = ['/tmp/workbuddy-a', '/tmp/workbuddy-b'].join(delimiter);
+  try { assert.deepEqual(findWorkbuddyDataDirs(), ['/tmp/workbuddy-a', '/tmp/workbuddy-b']); }
+  finally {
+    if (previous === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = previous;
   }
 });

--- a/test/workbuddy.test.js
+++ b/test/workbuddy.test.js
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from '../src/parsers/workbuddy.js';
+import { parsers } from '../src/parsers/index.js';
+import { TOOLS } from '../src/tools.js';
+import { findWorkbuddyDataDirs } from '../src/workbuddy-roots.js';
+
+function completedRecord({ id, model, timestamp, usage, rawUsage, cwd = '/private/repo/actual-project' }) {
+  return {
+    id,
+    timestamp,
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    cwd,
+    content: [{ type: 'text', text: 'PROMPT_AND_RESPONSE_MUST_NOT_LEAK' }],
+    message: { usage },
+    providerData: {
+      requestModelId: model,
+      usage,
+      ...(rawUsage ? { rawUsage } : {}),
+      conversationRequestId: 'not-a-dedup-key',
+    },
+  };
+}
+
+test('WorkBuddy is registered and honors its fixture root override', () => {
+  const prior = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+  process.env.VIBE_USAGE_WORKBUDDY_DIRS = '/tmp/workbuddy-a:/tmp/workbuddy-b';
+  try {
+    assert.equal(typeof parsers.workbuddy, 'function');
+    assert.equal(TOOLS.find(tool => tool.id === 'workbuddy')?.name, 'WorkBuddy');
+    assert.deepEqual(findWorkbuddyDataDirs(), ['/tmp/workbuddy-a', '/tmp/workbuddy-b']);
+  } finally {
+    if (prior === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = prior;
+  }
+});
+
+test('WorkBuddy splits inclusive cache/reasoning totals and retains actual routed models', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-workbuddy-'));
+  const firstProject = join(root, 'projects', 'encoded-project');
+  const copiedProject = join(root, 'projects', 'copied-project');
+  mkdirSync(firstProject, { recursive: true });
+  mkdirSync(copiedProject, { recursive: true });
+  const timestamp = '2026-08-10T00:50:30.000Z';
+  const hy3 = completedRecord({
+    id: 'request-hy3',
+    model: 'hy3',
+    timestamp,
+    usage: {
+      inputTokens: 34824,
+      outputTokens: 31,
+      totalTokens: 34855,
+      inputTokensDetails: [{ cached_tokens: 7488 }],
+      outputTokensDetails: [{ reasoning_tokens: 27 }],
+    },
+    rawUsage: {
+      prompt_tokens: 34824,
+      prompt_cache_hit_tokens: 7488,
+      prompt_cache_miss_tokens: 27336,
+      completion_tokens: 31,
+      completion_thinking_tokens: 27,
+      total_tokens: 34855,
+    },
+  });
+  const autoRouted = completedRecord({
+    id: 'request-auto-routed',
+    model: 'model-routed-by-auto',
+    timestamp,
+    usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 40 },
+    cwd: '/private/repo/another-project',
+  });
+  const pending = { ...completedRecord({
+    id: 'request-pending', model: 'must-not-count', timestamp,
+    usage: { inputTokens: 100, outputTokens: 20 },
+  }), status: 'pending' };
+  writeFileSync(join(firstProject, 'session-a.jsonl'), [
+    JSON.stringify(hy3),
+    JSON.stringify(autoRouted),
+    JSON.stringify(pending),
+    '{malformed',
+  ].join('\n') + '\n');
+  // WorkBuddy copies can occur between roots/projects. A top-level record id
+  // remains the canonical request identity, unlike conversationRequestId.
+  writeFileSync(join(copiedProject, 'session-copy.jsonl'), JSON.stringify(hy3) + '\n');
+
+  const prior = process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+  process.env.VIBE_USAGE_WORKBUDDY_DIRS = root;
+  try {
+    const result = await parse();
+    assert.equal(result.sessions.length, 0);
+    assert.equal(result.buckets.length, 2);
+    const byModel = Object.fromEntries(result.buckets.map(bucket => [bucket.model, bucket]));
+    assert.deepEqual(byModel.hy3, {
+      source: 'workbuddy', model: 'hy3', project: 'actual-project',
+      bucketStart: '2026-08-10T00:30:00.000Z',
+      inputTokens: 27336, outputTokens: 4, cachedInputTokens: 7488,
+      reasoningOutputTokens: 27, totalTokens: 27367,
+    });
+    assert.deepEqual(byModel['model-routed-by-auto'], {
+      source: 'workbuddy', model: 'model-routed-by-auto', project: 'another-project',
+      bucketStart: '2026-08-10T00:30:00.000Z',
+      inputTokens: 60, outputTokens: 20, cachedInputTokens: 40,
+      reasoningOutputTokens: 0, totalTokens: 80,
+    });
+    const serialized = JSON.stringify(result);
+    assert.equal(serialized.includes('PROMPT_AND_RESPONSE_MUST_NOT_LEAK'), false);
+    assert.equal(serialized.includes('/private/repo'), false);
+  } finally {
+    if (prior === undefined) delete process.env.VIBE_USAGE_WORKBUDDY_DIRS;
+    else process.env.VIBE_USAGE_WORKBUDDY_DIRS = prior;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #50

## What changed

- Adds a streaming WorkBuddy JSONL parser for completed assistant requests under `~/.workbuddy/projects/`.
- Attributes each bucket to `providerData.requestModelId` (then request metadata), so a WorkBuddy task using Auto is reported under the models actually routed for each request.
- Splits cache reads and reasoning tokens out of WorkBuddy's inclusive input/output totals, deduplicates by the top-level request record ID, and does not read WorkBuddy account/session-auth data or web APIs.
- Registers WorkBuddy in tool discovery, documents the scope, and adds a fixture-root hook.

## Validation

- `npm test` — 119 passing tests.
- New parser tests cover Hy3's observed cache/reasoning mapping, Auto routing to two distinct models, duplicate request IDs, completed-status filtering, malformed JSONL, and payload privacy.
- New local E2E test starts `runSync` against a mock HTTP server: the first run uploads two routed-model buckets; the unchanged second run performs zero ingest requests.
- Read-only smoke parse against local WorkBuddy data completed without warnings (153 buckets; 87 Hy3 buckets).

## Deployment note

The server-side `USAGE_SOURCES` registry must also include `workbuddy`; this client repository does not contain that backend source file. Existing servers soft-drop unknown sources, so this PR does not risk other tool uploads before that registration is deployed.