### PR TITLE
Fix hidden-project usage aggregation

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -6,7 +6,7 @@ import {
 } from './state.js';
 import { ingest, fetchSettings } from './api.js';
 import { createSyncClient, forBatch } from './client-meta.js';
-import { parsers } from './parsers/index.js';
+import { aggregateToBuckets, parsers } from './parsers/index.js';
 import { success, failure, arrow, link, dim } from './output.js';
 
 const BATCH_SIZE = 100;
@@ -29,6 +29,19 @@ export function resolveUploadProjectSetting(settings) {
 
 export function resolveCodexExtraHome(configured, temporary) {
   return temporary ?? configured;
+}
+
+// Parsers aggregate buckets while the original project is still present in
+// their identity. When project upload is disabled, changing every project to
+// `unknown` can make formerly distinct buckets share the same server key
+// (source, model, host, half-hour). Merge them again before the incremental
+// diff, otherwise state keeps only one hash and the server can retain one
+// project row instead of their combined usage.
+export function reaggregateHiddenProjectBuckets(buckets) {
+  return aggregateToBuckets(buckets.map(bucket => ({
+    ...bucket,
+    timestamp: new Date(bucket.bucketStart),
+  })));
 }
 
 export async function runSync({
@@ -70,7 +83,7 @@ export async function runSync({
     process.exit(1);
   }
 
-  const allBuckets = [];
+  let allBuckets = [];
   const allSessions = [];
   const parserResults = [];
   const parserProgress = [];
@@ -166,6 +179,7 @@ export async function runSync({
   if (!uploadProject) {
     for (const b of allBuckets) b.project = 'unknown';
     for (const s of allSessions) s.project = 'unknown';
+    allBuckets = reaggregateHiddenProjectBuckets(allBuckets);
   }
 
   // Incremental upload diff: parsers above emit a complete view of live local

--- a/test/sync-privacy.test.js
+++ b/test/sync-privacy.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { reaggregateHiddenProjectBuckets } from '../src/sync.js';
+
+test('hidden-project buckets merge before upload-state and server identities collide', () => {
+  const buckets = [
+    {
+      source: 'codex', model: 'gpt-test', project: 'project-a', hostname: 'host-a',
+      bucketStart: '2026-08-12T00:00:00.000Z',
+      inputTokens: 100, outputTokens: 10, cachedInputTokens: 1_000,
+      reasoningOutputTokens: 5, totalTokens: 115,
+    },
+    {
+      source: 'codex', model: 'gpt-test', project: 'project-b', hostname: 'host-a',
+      bucketStart: '2026-08-12T00:00:00.000Z',
+      inputTokens: 200, outputTokens: 20, cachedInputTokens: 2_000,
+      reasoningOutputTokens: 10, totalTokens: 230,
+    },
+    {
+      source: 'codex', model: 'gpt-test', project: 'project-c', hostname: 'host-b',
+      bucketStart: '2026-08-12T00:00:00.000Z',
+      inputTokens: 300, outputTokens: 30, cachedInputTokens: 3_000,
+      reasoningOutputTokens: 15, totalTokens: 345,
+    },
+  ].map(bucket => ({ ...bucket, project: 'unknown' }));
+
+  const result = reaggregateHiddenProjectBuckets(buckets);
+
+  assert.equal(result.length, 2);
+  const hostA = result.find(bucket => bucket.hostname === 'host-a');
+  const hostB = result.find(bucket => bucket.hostname === 'host-b');
+  assert.deepEqual(hostA, {
+    source: 'codex', model: 'gpt-test', project: 'unknown', hostname: 'host-a',
+    bucketStart: '2026-08-12T00:00:00.000Z',
+    inputTokens: 300, outputTokens: 30, cachedInputTokens: 3_000,
+    reasoningOutputTokens: 15, totalTokens: 345,
+  });
+  assert.deepEqual(hostB, {
+    source: 'codex', model: 'gpt-test', project: 'unknown', hostname: 'host-b',
+    bucketStart: '2026-08-12T00:00:00.000Z',
+    inputTokens: 300, outputTokens: 30, cachedInputTokens: 3_000,
+    reasoningOutputTokens: 15, totalTokens: 345,
+  });
+});


### PR DESCRIPTION
## Summary

- Re-aggregate usage buckets after replacing project names with `unknown`.
- Add regression coverage for multiple projects that collapse to the same anonymous server key.

## Root cause

Parsers initially aggregate buckets while the project name is part of their identity. When project upload is disabled, sync later replaces every project with `unknown`. Buckets from different projects can then share the same source, model, host, and half-hour key, but were not merged again before the incremental upload diff. State retained only one hash for that key and the service could retain a single row rather than the combined usage.

## Impact

Users who hide project names can have Codex (and other supported tool) usage undercounted when more than one project produces usage for the same model and half-hour. This change preserves the privacy setting while uploading the correctly summed anonymous bucket.

## Validation

`node --test test/sync-privacy.test.js test/codex.test.js test/state.test.js`

Result: 36 passed, 1 Windows-specific permission test skipped.
