### PR TITLE
fix(cursor): raise CSV fetch timeout under concurrent sync

### DIFF
--- a/src/parsers/cursor.js
+++ b/src/parsers/cursor.js
@@ -68,7 +68,9 @@ function decodeJwtSub(token) {
   }
 }
 
-const FETCH_TIMEOUT_MS = 10_000;
+// Under full sync many parsers hammer disk concurrently; cursor.com's CSV
+// export can still succeed but take >10s. A short timeout caused silent skips.
+const FETCH_TIMEOUT_MS = Number(process.env.VIBE_USAGE_CURSOR_FETCH_TIMEOUT_MS) || 30_000;
 
 async function fetchUsageCsv(token) {
   const url = `${(process.env.CURSOR_WEB_BASE_URL?.trim() || 'https://cursor.com').replace(/\/+$/, '')}/api/dashboard/export-usage-events-csv?strategy=tokens`;
@@ -190,7 +192,14 @@ export async function parse() {
     // Auth failure → bubble up so user sees they need to re-login in Cursor.
     // Tell sync.js this was not a successful empty snapshot so it preserves
     // Cursor's incremental state instead of pruning it as dead history.
-    if (err && err.skip) return { buckets: [], sessions: [], skipped: true };
+    if (err && err.skip) {
+      return {
+        buckets: [],
+        sessions: [],
+        skipped: true,
+        warnings: [`cursor: ${err.message}`],
+      };
+    }
     throw err;
   }
   const rows = parseCsv(csv);

--- a/src/parsers/cursor.js
+++ b/src/parsers/cursor.js
@@ -70,7 +70,17 @@ function decodeJwtSub(token) {
 
 // Under full sync many parsers hammer disk concurrently; cursor.com's CSV
 // export can still succeed but take >10s. A short timeout caused silent skips.
-const FETCH_TIMEOUT_MS = Number(process.env.VIBE_USAGE_CURSOR_FETCH_TIMEOUT_MS) || 30_000;
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+const MAX_FETCH_TIMEOUT_MS = 2_147_483_647;
+
+export function resolveCursorFetchTimeout(value) {
+  const timeout = Number(value);
+  return Number.isInteger(timeout) && timeout > 0 && timeout <= MAX_FETCH_TIMEOUT_MS
+    ? timeout
+    : DEFAULT_FETCH_TIMEOUT_MS;
+}
+
+const FETCH_TIMEOUT_MS = resolveCursorFetchTimeout(process.env.VIBE_USAGE_CURSOR_FETCH_TIMEOUT_MS);
 
 async function fetchUsageCsv(token) {
   const url = `${(process.env.CURSOR_WEB_BASE_URL?.trim() || 'https://cursor.com').replace(/\/+$/, '')}/api/dashboard/export-usage-events-csv?strategy=tokens`;

--- a/src/sync.js
+++ b/src/sync.js
@@ -20,6 +20,12 @@ function formatBytes(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
+/** Hide only Cursor's intentional transient fetch soft-skip in quiet (daemon) syncs. */
+export function shouldSuppressParserWarning(source, message, quiet) {
+  if (!quiet) return false;
+  return source === 'cursor' && message.startsWith('cursor: Cursor usage export skipped (');
+}
+
 export function resolveUploadProjectSetting(settings) {
   if (typeof settings?.uploadProject !== 'boolean') {
     const error = new Error('SETTINGS_UNAVAILABLE');
@@ -175,7 +181,8 @@ export async function runSync({
       parserProgress.push({ source, ...indexing });
     }
     for (const message of warnings) {
-      if (!quiet) process.stderr.write(`${dim(`  ${message}`)}\n`);
+      if (shouldSuppressParserWarning(source, message, quiet)) continue;
+      process.stderr.write(`${dim(`  ${message}`)}\n`);
     }
     // A parser may deliberately suppress a transient error (Cursor network
     // timeout) to keep daemon logs quiet. Its empty result is not proof that

--- a/src/sync.js
+++ b/src/sync.js
@@ -175,7 +175,7 @@ export async function runSync({
       parserProgress.push({ source, ...indexing });
     }
     for (const message of warnings) {
-      process.stderr.write(`${dim(`  ${message}`)}\n`);
+      if (!quiet) process.stderr.write(`${dim(`  ${message}`)}\n`);
     }
     // A parser may deliberately suppress a transient error (Cursor network
     // timeout) to keep daemon logs quiet. Its empty result is not proof that

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as cursor from '../src/parsers/cursor.js';
+
+test('Cursor fetch timeout accepts positive integers and defaults invalid values', () => {
+  assert.equal(typeof cursor.resolveCursorFetchTimeout, 'function');
+
+  const cases = [
+    [undefined, 30_000],
+    ['', 30_000],
+    ['0', 30_000],
+    ['-1', 30_000],
+    ['1.5', 30_000],
+    ['Infinity', 30_000],
+    ['2147483648', 30_000],
+    ['45000', 45_000],
+  ];
+
+  for (const [value, expected] of cases) {
+    assert.equal(cursor.resolveCursorFetchTimeout(value), expected);
+  }
+});

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -12,6 +12,7 @@ import {
   resolveCachedUploadProjectSetting,
   resolveUploadProjectSetting,
   mapWithConcurrency,
+  shouldSuppressParserWarning,
 } from '../src/sync.js';
 import { normalizeParserResult } from '../src/parsers/contract.js';
 
@@ -67,6 +68,22 @@ test('cached project-upload settings are scoped to the confirming API', () => {
 test('temporary extra Codex home overrides persisted config only for this run', () => {
   assert.equal(resolveCodexExtraHome('/persisted/.codex', '/temporary/.codex'), '/temporary/.codex');
   assert.equal(resolveCodexExtraHome('/persisted/.codex', undefined), '/persisted/.codex');
+});
+
+test('shouldSuppressParserWarning hides only Cursor transient fetch skips in quiet mode', () => {
+  assert.equal(
+    shouldSuppressParserWarning('cursor', 'cursor: Cursor usage export skipped (timeout)', true),
+    true,
+  );
+  assert.equal(
+    shouldSuppressParserWarning('cursor', 'cursor: Cursor usage export skipped (timeout)', false),
+    false,
+  );
+  assert.equal(shouldSuppressParserWarning('dsh', 'dsh: cannot read session-8', true), false);
+  assert.equal(
+    shouldSuppressParserWarning('cursor', 'cursor: cannot read usage database (locked)', true),
+    false,
+  );
 });
 
 test('mapWithConcurrency preserves order and bounds in-flight work', async () => {


### PR DESCRIPTION
## Summary

- Raise Cursor CSV export fetch timeout from 10s to 30s (override via `VIBE_USAGE_CURSOR_FETCH_TIMEOUT_MS`)
- Surface skip reasons as parser warnings so timeouts/network errors are visible in sync output instead of failing silently

Fixes #72

## Problem

During a full `sync`, many parsers run concurrently. Under that load, `cursor.com`'s usage CSV export still returns HTTP 200 but often after **>10s**. The old 10s timeout caused the parser to soft-skip with no user-visible error, so Cursor usage disappeared from sync output even though running the parser alone worked fine.

## Test plan

- [x] `npm test` passes (175 tests)
- [x] `node ./bin/vibe-usage.js sync` shows `cursor` in parser summary and uploads buckets
- [x] Concurrent parser run (full registry, concurrency 4) returns cursor buckets with 30s timeout
- [x] Skip path emits dim warning via `warnings` (e.g. on genuine timeout/network failure)


Made with [Cursor](https://cursor.com)