### PR TITLE
harden: add parameterized queries in cursor.js

### DIFF
--- a/src/parsers/cursor.js
+++ b/src/parsers/cursor.js
@@ -44,10 +44,10 @@ export function getCursorStateDbPath() {
 function readAccessToken(dbPath) {
   // Cursor app holds a write lock; queryDbJsonSnapshotOnLock copies the WAL set
   // to a temp dir and retries on "database is locked".
-  const sql = `SELECT value FROM ItemTable WHERE key = '${ACCESS_TOKEN_KEY}' LIMIT 1`;
+  const sql = 'SELECT value FROM ItemTable WHERE key = ? LIMIT 1';
   const rows = queryDbJsonSnapshotOnLock(dbPath, sql, {
     tempPrefix: 'vibe-usage-cursor-',
-    opts: { maxBuffer: 4 * 1024 * 1024, timeout: 15000 },
+    opts: { maxBuffer: 4 * 1024 * 1024, timeout: 15000, params: [ACCESS_TOKEN_KEY] },
   });
   const value = rows[0]?.value;
   if (typeof value !== 'string') return null;

--- a/src/parsers/sqlite.js
+++ b/src/parsers/sqlite.js
@@ -20,17 +20,17 @@ const require = createRequire(import.meta.url);
 export function queryDbJson(
   dbPath,
   sql,
-  { timeout = 30000, maxBuffer = 100 * 1024 * 1024, readOnly = true } = {},
+  { timeout = 30000, maxBuffer = 100 * 1024 * 1024, readOnly = true, params = [] } = {},
 ) {
   const db = openNodeSqlite(dbPath, readOnly);
   if (db) {
     try {
-      return db.prepare(sql).all();
+      return db.prepare(sql).all(...params);
     } finally {
       db.close();
     }
   }
-  return queryViaCli(dbPath, sql, { timeout, maxBuffer });
+  return queryViaCli(dbPath, sql, { timeout, maxBuffer, params });
 }
 
 let nodeSqlite; // undefined = not tried, null = unavailable
@@ -79,8 +79,12 @@ function openNodeSqlite(dbPath, readOnly = true) {
   }
 }
 
-function queryViaCli(dbPath, sql, { timeout, maxBuffer }) {
-  const out = execFileSync('sqlite3', ['-json', dbPath, sql], {
+function queryViaCli(dbPath, sql, { timeout, maxBuffer, params = [] }) {
+  const queue = [...params];
+  const bound = queue.length
+    ? sql.replace(/\?/g, () => `'${String(queue.shift()).replace(/'/g, "''")}'`)
+    : sql;
+  const out = execFileSync('sqlite3', ['-json', dbPath, bound], {
     encoding: 'utf-8',
     maxBuffer,
     timeout,


### PR DESCRIPTION
## Summary
Harden input handling in `src/parsers/cursor.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.sql-injection-template-literal |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.sql-injection-template-literal` |
| **File** | `src/parsers/cursor.js:47` |
| **Assessment** | Defensive hardening |

**Description**: SQL query constructed using JavaScript template literals with dynamic input. This can lead to SQL injection. Use parameterized queries instead.


## Threat Model Context

This is a Node.js command-line tool - exploitation requires the attacker to control the arguments, input files or environment the tool is run with.

## Changes
- `src/parsers/cursor.js`
- `src/parsers/sqlite.js`

## Behavior Preservation
The change is scoped to 2 files.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=utils.custom.sql-injection-template-literal scanner=semgrep -->
