### PR TITLE
feat(pi): 支持显式配置额外的 Pi 会话根目录

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx @vibe-cafe/vibe-usage status       # Show config & detected tools
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, `json_extract` query) |
 | OpenClaw | `~/.openclaw/agents/`, `~/.openclaw-<profile>/agents/` (profile deployments); cache-creation/cache-write tokens are included in input usage |
 | Oh My Pi | `~/.omp/agent/sessions/`, `~/.omp/profiles/*/agent/sessions/`, and `$XDG_DATA_HOME/omp/{sessions,profiles/*/sessions}`; recognizes OMP's `$PI_CODING_AGENT_DIR`, current v3 title slots and path/hashed session directories, deduplicates copied records, includes cache writes in input, and splits reasoning from OMP's inclusive output count |
-| pi | `~/.pi/agent/sessions/` or `$PI_CODING_AGENT_DIR/sessions/`, plus the session directory Pi itself was pointed at via `PI_CODING_AGENT_SESSION_DIR` or `sessionDir` in `~/.pi/agent/settings.json` (fixture/relocation override: `VIBE_USAGE_PI_SESSION_DIRS`). Cache writes are included in input usage; reasoning is read from Pi's `usage.reasoning` (legacy `usage.reasoningTokens` still accepted) and split out of the inclusive output total |
+| pi | `~/.pi/agent/sessions/` or `$PI_CODING_AGENT_DIR/sessions/`, plus the session directory Pi itself was pointed at via `PI_CODING_AGENT_SESSION_DIR` or `sessionDir` in `~/.pi/agent/settings.json`, plus explicitly added `pi-coding-agent` roots for stores only reachable through `pi --session <file>` (fixture/relocation override: `VIBE_USAGE_PI_SESSION_DIRS`). Cache writes are included in input usage; reasoning is read from Pi's `usage.reasoning` (legacy `usage.reasoningTokens` still accepted) and split out of the inclusive output total |
 | Qwen Code | `~/.qwen/tmp/` |
 | Kimi Code | Current `~/.kimi-code/sessions/wd_<slug>_<hash>/session_<id>/agents/<agent>/wire.jsonl` (`usage.record` deltas, including retry/compaction scope and cache creation; main/subagent wires form one session), data root resolved via `$KIMI_CODE_HOME` like the CLI itself, with project names from `session_index.jsonl`; legacy `~/.kimi/sessions/` is parsed alongside (`kimi migrate` never carries usage over, so both stores are always merged) |
 | MiniMax Code (mcode) | `$MCODE_HOME/v2/sqlite/runtime-state.sqlite` (default `~/.minimax/v2/sqlite/runtime-state.sqlite`; fixture override: `VIBE_USAGE_MCODE_DB`). Reads only allow-listed token ledger fields and session workspace/project paths, uses basename-only projects, folds cache writes into input, keeps cache reads and reasoning separate, and never selects raw/message JSON payloads. WAL/lock reads use a disposable snapshot; malformed or incompatible databases are skipped to preserve incremental state. |
@@ -158,7 +158,7 @@ Config stored at `~/.vibe-usage/config.json` (dev: `config.dev.json`).
 | `apiUrl` | Server URL (default: `https://vibecafe.ai`) |
 | `hostname` | Stable device name for usage tracking (set at init, reused across syncs) |
 | `codexExtraHome` | Optional additional Codex Home scanned together with `$CODEX_HOME` / `~/.codex` |
-| `extraRoots` | Tool-specific additional roots managed by the commands below; currently supports `codex`, `grok`, and `antigravity` |
+| `extraRoots` | Tool-specific additional roots managed by the commands below; currently supports `codex`, `grok`, `antigravity`, and `pi-coding-agent` |
 
 The `hostname` is captured once during `init` and reused for all future syncs. This prevents macOS mDNS hostname changes (e.g., `MacBook-Pro` → `MacBook-Pro-2`) from creating duplicate device entries. To change it manually:
 
@@ -178,6 +178,12 @@ npx @vibe-cafe/vibe-usage config add-root grok /path/to/grok-home
 
 # Antigravity expects an alternate HOME containing .gemini/antigravity*/conversations/.
 npx @vibe-cafe/vibe-usage config add-root antigravity /path/to/alternate-home
+
+# Pi accepts a directory that holds session .jsonl files directly, or a Pi
+# agent directory containing sessions/. Use this when a harness starts Pi with
+# `pi --session <file>`: that path is recorded nowhere Pi's own settings can
+# report, so it is invisible to discovery.
+npx @vibe-cafe/vibe-usage config add-root pi-coding-agent /path/to/pi-sessions
 
 npx @vibe-cafe/vibe-usage config roots
 npx @vibe-cafe/vibe-usage config remove-root grok /path/to/grok-home

--- a/src/extra-roots.js
+++ b/src/extra-roots.js
@@ -1,4 +1,4 @@
-import { accessSync, constants, readdirSync, statSync } from 'node:fs';
+import { accessSync, closeSync, constants, openSync, readSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { codexSessionDirs } from './codex-roots.js';
@@ -87,15 +87,67 @@ export function antigravityConversationDirs(value) {
 // them. Accept either shape, but resolve to exactly one directory per root:
 // the parser walks nested directories, so returning both a root and its
 // `sessions/` child would read every file twice.
+//
+// The shape is re-resolved on every run rather than remembered from add-root
+// time, and an unresolvable root returns null instead of falling back to the
+// root itself. Falling back would turn an agent home that lost its `sessions/`
+// child into a readable directory holding no sessions, i.e. exactly the silent
+// zero this feature exists to prevent.
 export function piSessionsDir(value) {
   const root = normalizeExtraRoot(value);
   const nested = join(root, 'sessions');
-  return isReadableDirectory(nested) ? nested : root;
+  if (isReadableDirectory(nested)) return nested;
+  if (isReadableDirectory(root) && hasPiSessionJsonl(root)) return root;
+  return null;
 }
 
-// A session store is only recognizable by the JSONL files in it. Stay shallow:
-// a configured root may sit next to large unrelated trees.
-function hasSessionJsonl(dir, depth = 2) {
+const PI_PROBE_BYTES = 16 * 1024;
+const PI_PROBE_LINES = 10;
+
+// A `.jsonl` extension proves nothing: an unrelated log would validate an
+// entirely wrong directory, which the parser then ignores without complaining.
+// Probe a bounded prefix for a record the Pi parser actually consumes — a
+// `session` header, or a `message` entry for an appended-to store.
+function looksLikePiSessionFile(filePath) {
+  let text;
+  let fd;
+  try {
+    fd = openSync(filePath, 'r');
+    const buffer = Buffer.alloc(PI_PROBE_BYTES);
+    const read = readSync(fd, buffer, 0, PI_PROBE_BYTES, 0);
+    text = buffer.subarray(0, read).toString('utf8');
+    // A prefix read can cut the final line in half; drop the partial tail.
+    if (read === PI_PROBE_BYTES) text = text.slice(0, text.lastIndexOf('\n') + 1);
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch { /* already closed */ }
+    }
+  }
+
+  let checked = 0;
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    if (++checked > PI_PROBE_LINES) return false;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!obj || typeof obj !== 'object') continue;
+    if (obj.type === 'session') return true;
+    if (obj.type === 'message' && obj.message && typeof obj.message === 'object') return true;
+  }
+  return false;
+}
+
+// A session store is only recognizable by the Pi session files in it. Stay
+// shallow: a configured root may sit next to large unrelated trees.
+function hasPiSessionJsonl(dir, depth = 2) {
   let children;
   try {
     children = readdirSync(dir, { withFileTypes: true });
@@ -104,10 +156,15 @@ function hasSessionJsonl(dir, depth = 2) {
   }
   // Dirent#isDirectory is false for symbolic links, matching the parser's own
   // walk: linked session files are read, linked directories are not entered.
-  if (children.some(child => !child.isDirectory() && child.name.endsWith('.jsonl'))) return true;
+  const hasFile = children.some(child => (
+    !child.isDirectory()
+    && child.name.endsWith('.jsonl')
+    && looksLikePiSessionFile(join(dir, child.name))
+  ));
+  if (hasFile) return true;
   if (depth <= 0) return false;
   return children.some(child => (
-    child.isDirectory() && hasSessionJsonl(join(dir, child.name), depth - 1)
+    child.isDirectory() && hasPiSessionJsonl(join(dir, child.name), depth - 1)
   ));
 }
 
@@ -127,9 +184,9 @@ export function validateExtraRoot(source, value) {
   if (source === 'pi-coding-agent') {
     const sessionsDir = piSessionsDir(path);
     return {
-      ok: isReadableDirectory(sessionsDir) && hasSessionJsonl(sessionsDir),
+      ok: sessionsDir !== null && hasPiSessionJsonl(sessionsDir),
       path,
-      reason: '需要是直接包含会话 .jsonl 的目录，或包含 sessions/ 的 Pi agent 目录',
+      reason: '需要是直接包含 Pi 会话 .jsonl 的目录，或包含 sessions/ 的 Pi agent 目录',
     };
   }
   const dirs = source === 'grok'

--- a/src/extra-roots.js
+++ b/src/extra-roots.js
@@ -108,11 +108,33 @@ export function piSessionsDir(value) {
   // outranks any `sessions/` child: those files are what the user configured.
   if (hasPiSessionJsonl(root, 0)) return root;
   const nested = join(root, 'sessions');
-  // Agent-home shape: take the child only once its content confirms it.
-  if (isReadableDirectory(nested) && hasPiSessionJsonl(nested)) return nested;
+  // Agent-home shape: narrowing to the child is only safe when every confirmed
+  // session lives below it. A container whose per-task stores happen to include
+  // one named `sessions` is still a container, and resolving it to that child
+  // would drop all its siblings — the same silent undercount as above.
+  if (isReadableDirectory(nested) && hasPiSessionJsonl(nested) && !hasPiSessionsOutsideNested(root)) {
+    return nested;
+  }
   // A configured container holding per-task stores somewhere below it.
   if (hasPiSessionJsonl(root)) return root;
   return null;
+}
+
+// True when a root holds confirmed sessions in some child other than
+// `sessions/`. The per-child depth is one less than the root scan's own so both
+// reach the same files.
+function hasPiSessionsOutsideNested(root) {
+  let children;
+  try {
+    children = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  return children.some(child => (
+    child.isDirectory()
+    && child.name !== 'sessions'
+    && hasPiSessionJsonl(join(root, child.name), 1)
+  ));
 }
 
 const PI_PROBE_BYTES = 16 * 1024;

--- a/src/extra-roots.js
+++ b/src/extra-roots.js
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { codexSessionDirs } from './codex-roots.js';
 
-export const EXTRA_ROOT_SOURCES = ['antigravity', 'codex', 'grok'];
+export const EXTRA_ROOT_SOURCES = ['antigravity', 'codex', 'grok', 'pi-coding-agent'];
 
 export function extraRootList(value) {
   return Array.isArray(value) ? value.filter(root => typeof root === 'string' && root.trim()) : [];
@@ -81,6 +81,36 @@ export function antigravityConversationDirs(value) {
   ];
 }
 
+// Pi's own discoverable settings (PI_CODING_AGENT_SESSION_DIR, `sessionDir` in
+// settings.json) name a sessions directory directly, and a harness that calls
+// `pi --session <file>` writes bare session trees with no agent home above
+// them. Accept either shape, but resolve to exactly one directory per root:
+// the parser walks nested directories, so returning both a root and its
+// `sessions/` child would read every file twice.
+export function piSessionsDir(value) {
+  const root = normalizeExtraRoot(value);
+  const nested = join(root, 'sessions');
+  return isReadableDirectory(nested) ? nested : root;
+}
+
+// A session store is only recognizable by the JSONL files in it. Stay shallow:
+// a configured root may sit next to large unrelated trees.
+function hasSessionJsonl(dir, depth = 2) {
+  let children;
+  try {
+    children = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  // Dirent#isDirectory is false for symbolic links, matching the parser's own
+  // walk: linked session files are read, linked directories are not entered.
+  if (children.some(child => !child.isDirectory() && child.name.endsWith('.jsonl'))) return true;
+  if (depth <= 0) return false;
+  return children.some(child => (
+    child.isDirectory() && hasSessionJsonl(join(dir, child.name), depth - 1)
+  ));
+}
+
 export function validateExtraRoot(source, value) {
   if (!EXTRA_ROOT_SOURCES.includes(source)) {
     return { ok: false, path: value, reason: `不支持的工具: ${source}` };
@@ -92,6 +122,14 @@ export function validateExtraRoot(source, value) {
       ok: result.readable && result.homes.length > 0,
       path,
       reason: '需要是 Codex Home，或包含 */*/codex-home 的 Multica 容器',
+    };
+  }
+  if (source === 'pi-coding-agent') {
+    const sessionsDir = piSessionsDir(path);
+    return {
+      ok: isReadableDirectory(sessionsDir) && hasSessionJsonl(sessionsDir),
+      path,
+      reason: '需要是直接包含会话 .jsonl 的目录，或包含 sessions/ 的 Pi agent 目录',
     };
   }
   const dirs = source === 'grok'

--- a/src/extra-roots.js
+++ b/src/extra-roots.js
@@ -86,7 +86,15 @@ export function antigravityConversationDirs(value) {
 // `pi --session <file>` writes bare session trees with no agent home above
 // them. Accept either shape, but resolve to exactly one directory per root:
 // the parser walks nested directories, so returning both a root and its
-// `sessions/` child would read every file twice.
+// `sessions/` child would read every file twice. Canonical-path dedup in the
+// parser makes the overlap harmless even for a mixed root that holds sessions
+// directly *and* under `sessions/`.
+//
+// Every candidate is confirmed by content, never by name alone. A readable but
+// unconfirmed `sessions/` child used to win unconditionally, so creating an
+// empty `<root>/sessions` was enough to redirect the scan away from a bare
+// store's own files — a successful sync reporting zero, which then pruned the
+// source's incremental state.
 //
 // The shape is re-resolved on every run rather than remembered from add-root
 // time, and an unresolvable root returns null instead of falling back to the
@@ -95,19 +103,57 @@ export function antigravityConversationDirs(value) {
 // zero this feature exists to prevent.
 export function piSessionsDir(value) {
   const root = normalizeExtraRoot(value);
+  if (!isReadableDirectory(root)) return null;
+  // A bare store is identified by the session files it holds directly, and
+  // outranks any `sessions/` child: those files are what the user configured.
+  if (hasPiSessionJsonl(root, 0)) return root;
   const nested = join(root, 'sessions');
-  if (isReadableDirectory(nested)) return nested;
-  if (isReadableDirectory(root) && hasPiSessionJsonl(root)) return root;
+  // Agent-home shape: take the child only once its content confirms it.
+  if (isReadableDirectory(nested) && hasPiSessionJsonl(nested)) return nested;
+  // A configured container holding per-task stores somewhere below it.
+  if (hasPiSessionJsonl(root)) return root;
   return null;
 }
 
 const PI_PROBE_BYTES = 16 * 1024;
 const PI_PROBE_LINES = 10;
+// Roles the Pi parser turns into events; anything else contributes nothing.
+const PI_MESSAGE_ROLES = new Set(['user', 'assistant', 'toolResult']);
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+// Pi's session format opens a store with a full SessionHeader. `version` is
+// written as both a number and a string across real stores, so only its
+// presence is required.
+function isPiSessionHeader(obj) {
+  return obj.type === 'session'
+    && obj.version !== undefined
+    && obj.version !== null
+    && isNonEmptyString(obj.id)
+    && isNonEmptyString(obj.timestamp)
+    && typeof obj.cwd === 'string';
+}
+
+// A store an external harness appends to may carry no header inside the probed
+// prefix, so a message record alone can confirm the directory — but only a
+// complete one. Matching on `type` and an object-valued `message` accepted
+// `{"type":"message","message":{}}`, which the parser reads to exactly zero.
+function isPiSessionMessage(obj) {
+  return obj.type === 'message'
+    && isNonEmptyString(obj.id)
+    && 'parentId' in obj
+    && isNonEmptyString(obj.timestamp)
+    && Boolean(obj.message)
+    && typeof obj.message === 'object'
+    && PI_MESSAGE_ROLES.has(obj.message.role);
+}
 
 // A `.jsonl` extension proves nothing: an unrelated log would validate an
 // entirely wrong directory, which the parser then ignores without complaining.
-// Probe a bounded prefix for a record the Pi parser actually consumes — a
-// `session` header, or a `message` entry for an appended-to store.
+// Neither does a bare `type` name — validation has to require the fields the
+// parser reads, or a malformed lookalike is accepted and still syncs zero.
 function looksLikePiSessionFile(filePath) {
   let text;
   let fd;
@@ -139,8 +185,7 @@ function looksLikePiSessionFile(filePath) {
       continue;
     }
     if (!obj || typeof obj !== 'object') continue;
-    if (obj.type === 'session') return true;
-    if (obj.type === 'message' && obj.message && typeof obj.message === 'object') return true;
+    if (isPiSessionHeader(obj) || isPiSessionMessage(obj)) return true;
   }
   return false;
 }
@@ -182,9 +227,10 @@ export function validateExtraRoot(source, value) {
     };
   }
   if (source === 'pi-coding-agent') {
-    const sessionsDir = piSessionsDir(path);
+    // piSessionsDir only returns a directory it has already confirmed by
+    // content, so there is nothing left to re-check here.
     return {
-      ok: sessionsDir !== null && hasPiSessionJsonl(sessionsDir),
+      ok: piSessionsDir(path) !== null,
       path,
       reason: '需要是直接包含 Pi 会话 .jsonl 的目录，或包含 sessions/ 的 Pi agent 目录',
     };

--- a/src/extra-roots.js
+++ b/src/extra-roots.js
@@ -5,6 +5,14 @@ import { codexSessionDirs } from './codex-roots.js';
 
 export const EXTRA_ROOT_SOURCES = ['antigravity', 'codex', 'grok', 'pi-coding-agent'];
 
+// Probing a candidate Pi store has three outcomes, never two: a confirmed
+// session, a directory proven to hold none, and one that could not be read.
+// Collapsing the last two into a single false is what let an unreadable subtree
+// be treated as an empty one.
+const PI_SESSIONS_FOUND = 'found';
+const PI_SESSIONS_ABSENT = 'absent';
+const PI_SESSIONS_UNREADABLE = 'unreadable';
+
 export function extraRootList(value) {
   return Array.isArray(value) ? value.filter(root => typeof root === 'string' && root.trim()) : [];
 }
@@ -101,40 +109,61 @@ export function antigravityConversationDirs(value) {
 // root itself. Falling back would turn an agent home that lost its `sessions/`
 // child into a readable directory holding no sessions, i.e. exactly the silent
 // zero this feature exists to prevent.
+//
+// Probing is tri-state on purpose. A boolean collapsed "holds no sessions" into
+// "could not be read", so making one sibling store unreadable was enough to
+// make a container look like an agent home and narrow the scan to `sessions/`,
+// dropping every readable sibling with no `skipped` flag. Absence has to be
+// proven; where it is only assumed, resolution gives up and the caller skips.
 export function piSessionsDir(value) {
   const root = normalizeExtraRoot(value);
   if (!isReadableDirectory(root)) return null;
   // A bare store is identified by the session files it holds directly, and
   // outranks any `sessions/` child: those files are what the user configured.
-  if (hasPiSessionJsonl(root, 0)) return root;
+  const direct = probePiSessions(root, 0);
+  if (direct === PI_SESSIONS_FOUND) return root;
+
+  const outside = probePiSessionsOutsideNested(root);
+  // Both decisions below rest on absence: that the root holds no sessions
+  // directly, and that no sibling of `sessions/` holds any. An unreadable
+  // candidate proves neither, so stop rather than narrow past it.
+  if (direct === PI_SESSIONS_UNREADABLE || outside === PI_SESSIONS_UNREADABLE) return null;
+
   const nested = join(root, 'sessions');
   // Agent-home shape: narrowing to the child is only safe when every confirmed
   // session lives below it. A container whose per-task stores happen to include
   // one named `sessions` is still a container, and resolving it to that child
   // would drop all its siblings — the same silent undercount as above.
-  if (isReadableDirectory(nested) && hasPiSessionJsonl(nested) && !hasPiSessionsOutsideNested(root)) {
+  if (
+    outside === PI_SESSIONS_ABSENT
+    && isReadableDirectory(nested)
+    && probePiSessions(nested) === PI_SESSIONS_FOUND
+  ) {
     return nested;
   }
-  // A configured container holding per-task stores somewhere below it.
-  if (hasPiSessionJsonl(root)) return root;
-  return null;
+  // A configured container holding per-task stores somewhere below it. Anything
+  // else — no sessions at all, or a subtree that could not be read — resolves
+  // to null, which the parser reports as skipped instead of as an empty sync.
+  return probePiSessions(root) === PI_SESSIONS_FOUND ? root : null;
 }
 
-// True when a root holds confirmed sessions in some child other than
-// `sessions/`. The per-child depth is one less than the root scan's own so both
-// reach the same files.
-function hasPiSessionsOutsideNested(root) {
+// Confirmed sessions in some child other than `sessions/`. The per-child depth
+// is one less than the root scan's own so both reach the same files.
+function probePiSessionsOutsideNested(root) {
   let children;
   try {
     children = readdirSync(root, { withFileTypes: true });
   } catch {
-    return false;
+    return PI_SESSIONS_UNREADABLE;
   }
-  return children.some(child => (
-    child.isDirectory()
-    && child.name !== 'sessions'
-    && hasPiSessionJsonl(join(root, child.name), 1)
-  ));
+  let unreadable = false;
+  for (const child of children) {
+    if (!child.isDirectory() || child.name === 'sessions') continue;
+    const probe = probePiSessions(join(root, child.name), 1);
+    if (probe === PI_SESSIONS_FOUND) return PI_SESSIONS_FOUND;
+    if (probe === PI_SESSIONS_UNREADABLE) unreadable = true;
+  }
+  return unreadable ? PI_SESSIONS_UNREADABLE : PI_SESSIONS_ABSENT;
 }
 
 const PI_PROBE_BYTES = 16 * 1024;
@@ -176,7 +205,9 @@ function isPiSessionMessage(obj) {
 // entirely wrong directory, which the parser then ignores without complaining.
 // Neither does a bare `type` name — validation has to require the fields the
 // parser reads, or a malformed lookalike is accepted and still syncs zero.
-function looksLikePiSessionFile(filePath) {
+// A file that cannot be opened is reported as unreadable, not as "not a
+// session": it may well be the store the user configured.
+function probePiSessionFile(filePath) {
   let text;
   let fd;
   try {
@@ -187,7 +218,7 @@ function looksLikePiSessionFile(filePath) {
     // A prefix read can cut the final line in half; drop the partial tail.
     if (read === PI_PROBE_BYTES) text = text.slice(0, text.lastIndexOf('\n') + 1);
   } catch {
-    return false;
+    return PI_SESSIONS_UNREADABLE;
   } finally {
     if (fd !== undefined) {
       try {
@@ -199,7 +230,7 @@ function looksLikePiSessionFile(filePath) {
   let checked = 0;
   for (const line of text.split('\n')) {
     if (!line.trim()) continue;
-    if (++checked > PI_PROBE_LINES) return false;
+    if (++checked > PI_PROBE_LINES) return PI_SESSIONS_ABSENT;
     let obj;
     try {
       obj = JSON.parse(line);
@@ -207,32 +238,43 @@ function looksLikePiSessionFile(filePath) {
       continue;
     }
     if (!obj || typeof obj !== 'object') continue;
-    if (isPiSessionHeader(obj) || isPiSessionMessage(obj)) return true;
+    if (isPiSessionHeader(obj) || isPiSessionMessage(obj)) return PI_SESSIONS_FOUND;
   }
-  return false;
+  return PI_SESSIONS_ABSENT;
 }
 
 // A session store is only recognizable by the Pi session files in it. Stay
 // shallow: a configured root may sit next to large unrelated trees.
-function hasPiSessionJsonl(dir, depth = 2) {
+//
+// `found` outranks `unreadable`: one confirmed session is enough to resolve the
+// shape, and the shared parser reports whatever it cannot read on the way in.
+// `unreadable` outranks `absent`, so a caller never mistakes a subtree it could
+// not open for one it proved empty.
+function probePiSessions(dir, depth = 2) {
   let children;
   try {
     children = readdirSync(dir, { withFileTypes: true });
   } catch {
-    return false;
+    return PI_SESSIONS_UNREADABLE;
   }
+  let unreadable = false;
   // Dirent#isDirectory is false for symbolic links, matching the parser's own
   // walk: linked session files are read, linked directories are not entered.
-  const hasFile = children.some(child => (
-    !child.isDirectory()
-    && child.name.endsWith('.jsonl')
-    && looksLikePiSessionFile(join(dir, child.name))
-  ));
-  if (hasFile) return true;
-  if (depth <= 0) return false;
-  return children.some(child => (
-    child.isDirectory() && hasPiSessionJsonl(join(dir, child.name), depth - 1)
-  ));
+  for (const child of children) {
+    if (child.isDirectory() || !child.name.endsWith('.jsonl')) continue;
+    const probe = probePiSessionFile(join(dir, child.name));
+    if (probe === PI_SESSIONS_FOUND) return PI_SESSIONS_FOUND;
+    if (probe === PI_SESSIONS_UNREADABLE) unreadable = true;
+  }
+  if (depth > 0) {
+    for (const child of children) {
+      if (!child.isDirectory()) continue;
+      const probe = probePiSessions(join(dir, child.name), depth - 1);
+      if (probe === PI_SESSIONS_FOUND) return PI_SESSIONS_FOUND;
+      if (probe === PI_SESSIONS_UNREADABLE) unreadable = true;
+    }
+  }
+  return unreadable ? PI_SESSIONS_UNREADABLE : PI_SESSIONS_ABSENT;
 }
 
 export function validateExtraRoot(source, value) {

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ function handleConfig(args) {
       const source = args[1];
       const value = args[2];
       if (!source || value === undefined) {
-        console.error('Usage: vibe-usage config add-root <codex|grok|antigravity> <path>');
+        console.error(`Usage: vibe-usage config add-root <${EXTRA_ROOT_SOURCES.join('|')}> <path>`);
         process.exit(1);
       }
       const validation = validateExtraRoot(source, value);
@@ -142,7 +142,7 @@ function handleConfig(args) {
       const source = args[1];
       const value = args[2];
       if (!EXTRA_ROOT_SOURCES.includes(source) || value === undefined) {
-        console.error('Usage: vibe-usage config remove-root <codex|grok|antigravity> <path>');
+        console.error(`Usage: vibe-usage config remove-root <${EXTRA_ROOT_SOURCES.join('|')}> <path>`);
         process.exit(1);
       }
       const config = loadConfig() || {};
@@ -297,7 +297,7 @@ export async function run(rawArgs) {
     npx @vibe-cafe/vibe-usage config get <key>   Get a config value
     npx @vibe-cafe/vibe-usage config set <key> <value>  Set a config value
     npx @vibe-cafe/vibe-usage config set codexExtraHome <path>  Persist another Codex Home
-    npx @vibe-cafe/vibe-usage config add-root <tool> <path>  Add a Codex, Grok, or Antigravity data root
+    npx @vibe-cafe/vibe-usage config add-root <tool> <path>  Add a Codex, Grok, Antigravity, or Pi data root
     npx @vibe-cafe/vibe-usage config remove-root <tool> <path>  Remove an added data root
     npx @vibe-cafe/vibe-usage config roots  Show added data roots as JSON
     npx @vibe-cafe/vibe-usage help         Show this help

--- a/src/parsers/pi-coding-agent.js
+++ b/src/parsers/pi-coding-agent.js
@@ -1,4 +1,3 @@
-import { statSync } from 'node:fs';
 import { normalizeExtraRoot, piSessionsDir } from '../extra-roots.js';
 import { getPiSessionDirs } from '../pi-roots.js';
 import { mergeCindyHarnessUsage, readCindyHarnessUsage } from './cindy-ledger.js';
@@ -7,18 +6,17 @@ import { parsePiSessionJsonl } from './pi-session-jsonl.js';
 /** Parse the official Pi agent's Pi-compatible JSONL sessions. */
 export async function parse({ extraRoots = [] } = {}) {
   for (const root of extraRoots) {
-    try {
-      if (!statSync(piSessionsDir(root)).isDirectory()) throw new Error('not a directory');
-    } catch {
-      // An explicitly configured root that is momentarily unreadable is not
-      // proof that its usage disappeared, so skip instead of reporting empty.
-      return {
-        buckets: [],
-        sessions: [],
-        skipped: true,
-        warnings: [`pi-coding-agent: 额外根目录不可用，已跳过本次 Pi 同步: ${normalizeExtraRoot(root)}`],
-      };
-    }
+    // piSessionsDir re-resolves the root's shape, so an agent home that lost
+    // its `sessions/` child is caught here too, not just a root that vanished.
+    if (piSessionsDir(root) !== null) continue;
+    // An explicitly configured root that is momentarily unreadable is not
+    // proof that its usage disappeared, so skip instead of reporting empty.
+    return {
+      buckets: [],
+      sessions: [],
+      skipped: true,
+      warnings: [`pi-coding-agent: 额外根目录不可用，已跳过本次 Pi 同步: ${normalizeExtraRoot(root)}`],
+    };
   }
 
   const nativeResult = await parsePiSessionJsonl({

--- a/src/parsers/pi-coding-agent.js
+++ b/src/parsers/pi-coding-agent.js
@@ -1,12 +1,29 @@
+import { statSync } from 'node:fs';
+import { normalizeExtraRoot, piSessionsDir } from '../extra-roots.js';
 import { getPiSessionDirs } from '../pi-roots.js';
 import { mergeCindyHarnessUsage, readCindyHarnessUsage } from './cindy-ledger.js';
 import { parsePiSessionJsonl } from './pi-session-jsonl.js';
 
 /** Parse the official Pi agent's Pi-compatible JSONL sessions. */
-export async function parse() {
+export async function parse({ extraRoots = [] } = {}) {
+  for (const root of extraRoots) {
+    try {
+      if (!statSync(piSessionsDir(root)).isDirectory()) throw new Error('not a directory');
+    } catch {
+      // An explicitly configured root that is momentarily unreadable is not
+      // proof that its usage disappeared, so skip instead of reporting empty.
+      return {
+        buckets: [],
+        sessions: [],
+        skipped: true,
+        warnings: [`pi-coding-agent: 额外根目录不可用，已跳过本次 Pi 同步: ${normalizeExtraRoot(root)}`],
+      };
+    }
+  }
+
   const nativeResult = await parsePiSessionJsonl({
     source: 'pi-coding-agent',
-    sessionsDirs: getPiSessionDirs(),
+    sessionsDirs: getPiSessionDirs(extraRoots),
   });
   return mergeCindyHarnessUsage(nativeResult, readCindyHarnessUsage('pi'));
 }

--- a/src/parsers/pi-session-jsonl.js
+++ b/src/parsers/pi-session-jsonl.js
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { basename, join, relative } from 'node:path';
 import { aggregateToBuckets, extractSessions } from './aggregate.js';
 import { projectFromCwd, toCount } from './fs-utils.js';
@@ -38,6 +38,19 @@ export function projectFromFirstDir(filePath, sessionsDir) {
   return first.split('-').filter(Boolean).at(-1) || 'unknown';
 }
 
+// Configured stores can overlap: an ancestor and its descendant, or two paths
+// that resolve to the same place through a symlink. Record-level dedup only
+// covers entries carrying an `id`, so the same anonymous record would be
+// counted once per path that reaches it. Collapse on the canonical file path
+// instead, which also folds symlinked duplicates of a single file.
+function canonicalFilePath(filePath) {
+  try {
+    return realpathSync.native(filePath);
+  } catch {
+    return filePath;
+  }
+}
+
 export async function parsePiSessionJsonl({
   source,
   sessionsDirs,
@@ -49,9 +62,14 @@ export async function parsePiSessionJsonl({
   const anonymousEntries = [];
   const eventsById = new Map();
   const anonymousEvents = [];
+  const seenFiles = new Set();
 
   for (const sessionsDir of sessionsDirs) {
     for (const filePath of findJsonlFiles(sessionsDir, includeFile, ctx)) {
+      const canonical = canonicalFilePath(filePath);
+      if (seenFiles.has(canonical)) continue;
+      seenFiles.add(canonical);
+
       let content;
       try {
         content = readFileSync(filePath, 'utf8');

--- a/src/pi-roots.js
+++ b/src/pi-roots.js
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { delimiter, isAbsolute, join } from 'node:path';
 import { homedir } from 'node:os';
+import { piSessionsDir } from './extra-roots.js';
 
 function expandHome(value) {
   const trimmed = value.trim();
@@ -60,22 +61,29 @@ function settingsSessionDir(agentDir) {
   }
 }
 
-export function getPiSessionDirs() {
+export function getPiSessionDirs(extraRoots = []) {
+  // Explicitly configured roots are user intent, not a fixture: they are always
+  // scanned, and they never replace the default store.
+  const extraDirs = extraRoots.map(piSessionsDir);
+
   const override = process.env.VIBE_USAGE_PI_SESSION_DIRS?.trim();
-  if (override) return uniqueExistingDirs(override.split(delimiter));
+  if (override) return uniqueExistingDirs([...override.split(delimiter), ...extraDirs]);
 
   const envAgentDir = process.env.PI_CODING_AGENT_DIR?.trim();
   const agentDir = envAgentDir ? expandHome(envAgentDir) : join(homedir(), '.pi', 'agent');
   // OMP inherits PI_CODING_AGENT_DIR from Pi. Do not parse an identifiable
   // OMP store again as source=pi-coding-agent.
-  if (envAgentDir && looksLikeOmpAgentDir(agentDir)) return [];
+  const isOmpStore = Boolean(envAgentDir) && looksLikeOmpAgentDir(agentDir);
 
-  const dirs = [join(agentDir, 'sessions')];
-  const envSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR?.trim();
-  if (envSessionDir) dirs.push(expandHome(envSessionDir));
-  const configured = settingsSessionDir(agentDir);
-  if (configured) dirs.push(configured);
-  return uniqueExistingDirs(dirs);
+  const dirs = [];
+  if (!isOmpStore) {
+    dirs.push(join(agentDir, 'sessions'));
+    const envSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR?.trim();
+    if (envSessionDir) dirs.push(expandHome(envSessionDir));
+    const configured = settingsSessionDir(agentDir);
+    if (configured) dirs.push(configured);
+  }
+  return uniqueExistingDirs([...dirs, ...extraDirs]);
 }
 
 export function getOmpSessionDirs() {

--- a/src/pi-roots.js
+++ b/src/pi-roots.js
@@ -63,8 +63,9 @@ function settingsSessionDir(agentDir) {
 
 export function getPiSessionDirs(extraRoots = []) {
   // Explicitly configured roots are user intent, not a fixture: they are always
-  // scanned, and they never replace the default store.
-  const extraDirs = extraRoots.map(piSessionsDir);
+  // scanned, and they never replace the default store. A root whose shape no
+  // longer resolves drops out here; the parser reports that as skipped.
+  const extraDirs = extraRoots.map(piSessionsDir).filter(dir => dir !== null);
 
   const override = process.env.VIBE_USAGE_PI_SESSION_DIRS?.trim();
   if (override) return uniqueExistingDirs([...override.split(delimiter), ...extraDirs]);

--- a/src/tools.js
+++ b/src/tools.js
@@ -320,7 +320,9 @@ export const TOOLS = [
     name: 'pi',
     id: 'pi-coding-agent',
     dataDir: join(homedir(), '.pi', 'agent', 'sessions'),
-    detectDataDirs: findPiDataDirs,
+    detectDataDirs: ({ extraRoots } = {}) => (
+      findPiDataDirs(extraRootList(extraRoots?.['pi-coding-agent']))
+    ),
   },
   {
     name: 'Qwen Code',

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -202,6 +202,7 @@ test('config add-root accepts a Pi session store and reports it in status', () =
   mkdirSync(piStore, { recursive: true });
   writeFileSync(join(piStore, 'session-1.jsonl'), `${JSON.stringify({
     type: 'session',
+    version: 3,
     id: 'session-1',
     timestamp: '2026-09-01T00:00:00.000Z',
     cwd: '/work/harness',

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -194,6 +194,40 @@ test('config add-root, roots, and remove-root manage tool-specific roots without
   }
 });
 
+test('config add-root accepts a Pi session store and reports it in status', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-cli-pi-root-'));
+  const configDir = join(root, 'config');
+  const piStore = join(root, 'harness-sessions');
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(piStore, { recursive: true });
+  writeFileSync(join(piStore, 'session-1.jsonl'), `${JSON.stringify({
+    type: 'session',
+    id: 'session-1',
+    timestamp: '2026-09-01T00:00:00.000Z',
+    cwd: '/work/harness',
+  })}\n`);
+  writeFileSync(join(configDir, 'config.json'), JSON.stringify({ apiKey: 'vbu_test' }));
+  const env = { VIBE_USAGE_CONFIG_DIR: configDir, HOME: root };
+  try {
+    const add = runWithEnv(['config', 'add-root', 'pi-coding-agent', piStore], env);
+    assert.equal(add.status, 0, add.stderr);
+    const listed = runWithEnv(['config', 'roots'], env);
+    assert.deepEqual(JSON.parse(listed.stdout), { 'pi-coding-agent': [piStore] });
+
+    // An added root also makes the tool detected, not just scanned.
+    const status = runWithEnv(['status'], env);
+    assert.equal(status.status, 0, status.stderr);
+    assert.match(status.stdout, /Extra pi-coding-agent Root: /);
+    assert.match(status.stdout, /Detected tools:[\s\S]*pi/);
+
+    const empty = runWithEnv(['config', 'add-root', 'pi-coding-agent', configDir], env);
+    assert.equal(empty.status, 1);
+    assert.match(empty.stderr, /需要是直接包含会话 \.jsonl 的目录/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('config add-root rejects unsupported tools and invalid layouts', () => {
   const root = mkdtempSync(join(tmpdir(), 'vibe-usage-cli-invalid-root-'));
   try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -222,7 +222,16 @@ test('config add-root accepts a Pi session store and reports it in status', () =
 
     const empty = runWithEnv(['config', 'add-root', 'pi-coding-agent', configDir], env);
     assert.equal(empty.status, 1);
-    assert.match(empty.stderr, /需要是直接包含会话 \.jsonl 的目录/);
+    assert.match(empty.stderr, /需要是直接包含 Pi 会话 \.jsonl 的目录/);
+
+    // A same-extension log that is not a Pi session must be rejected too:
+    // accepting it would persist a root the parser then silently ignores.
+    const notPi = join(root, 'unrelated-logs');
+    mkdirSync(notPi, { recursive: true });
+    writeFileSync(join(notPi, 'events.jsonl'), '{"kind":"not-a-pi-session"}\n');
+    const wrong = runWithEnv(['config', 'add-root', 'pi-coding-agent', notPi], env);
+    assert.equal(wrong.status, 1);
+    assert.match(wrong.stderr, /需要是直接包含 Pi 会话 \.jsonl 的目录/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/pi-compatible.test.js
+++ b/test/pi-compatible.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parse as parseCraftAgent } from '../src/parsers/craft-agent.js';
@@ -536,6 +536,84 @@ test('Pi scans a whole container even when one task store is named sessions/', a
       17,
     );
   } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Readability failures inside a supported container shape used to be reported
+// as "this subtree holds no sessions", which re-ran the container-vs-agent-home
+// decision on false evidence.
+test('Pi skips a container whose sibling store is temporarily unreadable', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-unreadable-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  const blocked = [];
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    const container = join(root, 'container');
+    const task = join(container, 'task-a');
+    const named = join(container, 'sessions');
+    mkdirSync(task, { recursive: true });
+    mkdirSync(named, { recursive: true });
+    writeFileSync(join(task, 'task.jsonl'), anonymousSessionLines({ sessionId: 'task-a', input: 10 }));
+    writeFileSync(join(named, 'named.jsonl'), anonymousSessionLines({ sessionId: 'named', input: 7 }));
+
+    assert.equal(piSessionsDir(container), container);
+    const before = await parsePi({ extraRoots: [container] });
+    assert.equal(before.skipped, undefined);
+    assert.equal(before.buckets.reduce((sum, { inputTokens }) => sum + inputTokens, 0), 17);
+
+    // Only the sibling store loses read permission; the container and its
+    // `sessions/` child stay readable. Reading that failure as "task-a holds no
+    // sessions" narrowed the scan to `sessions/` and reported 7 as a success,
+    // dropping the other 10 and pruning its already-uploaded state.
+    chmodSync(task, 0o000);
+    blocked.push(task);
+    assert.equal(piSessionsDir(container), null);
+    const during = await parsePi({ extraRoots: [container] });
+    assert.equal(during.skipped, true);
+    assert.deepEqual(during.buckets, []);
+    assert.deepEqual(during.sessions, []);
+    assert.match(during.warnings.join('\n'), /额外根目录不可用/);
+
+    // The same evidence at file level: an unreadable store file next to a
+    // confirmed `sessions/` child must not resolve to that child either.
+    const mixed = join(root, 'mixed');
+    const mixedNested = join(mixed, 'sessions');
+    mkdirSync(mixedNested, { recursive: true });
+    writeFileSync(join(mixedNested, 'nested.jsonl'), anonymousSessionLines({ sessionId: 'n', input: 7 }));
+    const blockedFile = join(mixed, 'root.jsonl');
+    writeFileSync(blockedFile, anonymousSessionLines({ sessionId: 'r', input: 10 }));
+    chmodSync(blockedFile, 0o000);
+    blocked.push(blockedFile);
+    assert.equal(piSessionsDir(mixed), null);
+    const mixedResult = await parsePi({ extraRoots: [mixed] });
+    assert.equal(mixedResult.skipped, true);
+    assert.deepEqual(mixedResult.buckets, []);
+
+    // Both roots resolve again once the permission is restored, so a transient
+    // failure costs one sync instead of the source's history.
+    for (const path of blocked.splice(0)) chmodSync(path, 0o700);
+    assert.equal(piSessionsDir(container), container);
+    assert.equal(piSessionsDir(mixed), mixed);
+    const after = await parsePi({ extraRoots: [container] });
+    assert.equal(after.skipped, undefined);
+    assert.equal(after.buckets.reduce((sum, { inputTokens }) => sum + inputTokens, 0), 17);
+  } finally {
+    for (const path of blocked) {
+      try {
+        chmodSync(path, 0o700);
+      } catch { /* already restored */ }
+    }
     for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/pi-compatible.test.js
+++ b/test/pi-compatible.test.js
@@ -503,6 +503,44 @@ test('Pi keeps scanning a bare store when an unrelated sessions/ child appears',
   }
 });
 
+test('Pi scans a whole container even when one task store is named sessions/', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-container-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    // A supported container root: per-task stores below it, one of which
+    // happens to be called `sessions`. Preferring that name made the root look
+    // like an agent home and dropped every sibling store — silently, because
+    // the surviving child still parses successfully.
+    const container = join(root, 'container');
+    const task = join(container, 'task-a');
+    const named = join(container, 'sessions');
+    mkdirSync(task, { recursive: true });
+    mkdirSync(named, { recursive: true });
+    writeFileSync(join(task, 'task.jsonl'), anonymousSessionLines({ sessionId: 'task-a', input: 10 }));
+    writeFileSync(join(named, 'named.jsonl'), anonymousSessionLines({ sessionId: 'named', input: 7 }));
+
+    assert.equal(validateExtraRoot('pi-coding-agent', container).ok, true);
+    assert.equal(piSessionsDir(container), container);
+    const result = await parsePi({ extraRoots: [container] });
+    assert.equal(result.skipped, undefined);
+    assert.equal(
+      result.buckets.reduce((sum, { inputTokens }) => sum + inputTokens, 0),
+      17,
+    );
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('Pi counts an anonymous record once when extra roots overlap', async () => {
   const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-overlap-'));
   const previous = Object.fromEntries([

--- a/test/pi-compatible.test.js
+++ b/test/pi-compatible.test.js
@@ -7,6 +7,7 @@ import { parse as parseCraftAgent } from '../src/parsers/craft-agent.js';
 import { parse as parseOmp } from '../src/parsers/omp.js';
 import { parse as parsePi } from '../src/parsers/pi-coding-agent.js';
 import { getOmpSessionDirs, getPiSessionDirs } from '../src/pi-roots.js';
+import { validateExtraRoot } from '../src/extra-roots.js';
 
 const previousCindyDirs = process.env.VIBE_USAGE_CINDY_DIRS;
 process.env.VIBE_USAGE_CINDY_DIRS = join(tmpdir(), 'vibe-usage-cindy-disabled');
@@ -159,6 +160,11 @@ test('OMP discovers XDG profiles and does not also label its agent store as Pi',
     assert.ok(ompDirs.includes(xdgProfile));
     assert.ok(ompDirs.includes(overriddenSession));
     assert.deepEqual(getPiSessionDirs(), []);
+    // The OMP guard suppresses discovery of an OMP store as Pi; it must not
+    // discard a root the user added explicitly.
+    const piStore = join(root, 'pi-sessions');
+    mkdirSync(piStore, { recursive: true });
+    assert.deepEqual(getPiSessionDirs([piStore]), [piStore]);
   } finally {
     for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
     rmSync(root, { recursive: true, force: true });
@@ -250,6 +256,72 @@ test('Pi discovery honors PI_CODING_AGENT_SESSION_DIR alongside the agent store'
     assert.ok(dirs.includes(relocated));
   } finally {
     for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi scans an explicitly configured extra session root that discovery cannot see', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    const agentDir = join(root, 'agent');
+    const agentSessions = join(agentDir, 'sessions');
+    // A harness that runs `pi --session <file>` writes a flat store with no
+    // agent directory above it, so nothing in Pi's own settings names it.
+    const harnessStore = join(root, 'harness-sessions');
+    mkdirSync(agentSessions, { recursive: true });
+    mkdirSync(harnessStore, { recursive: true });
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    writeSession(agentSessions, 'default/session-default.jsonl', { sessionId: 'session-default' });
+    writeFileSync(join(harnessStore, 'session-harness.jsonl'), sessionLines({
+      sessionId: 'session-harness',
+      cwd: '/work/harness',
+    }));
+
+    // Discovery alone still stops at the default store.
+    assert.deepEqual(getPiSessionDirs(), [agentSessions]);
+    assert.equal(validateExtraRoot('pi-coding-agent', harnessStore).ok, true);
+    assert.deepEqual(getPiSessionDirs([harnessStore]), [agentSessions, harnessStore]);
+
+    const result = await parsePi({ extraRoots: [harnessStore] });
+    assert.equal(result.skipped, undefined);
+    // Sessions are reported hashed, so assert on the project each store maps to.
+    assert.deepEqual(result.sessions.map(({ project }) => project).sort(), ['harness', 'project']);
+    assert.deepEqual(result.buckets.map(({ project }) => project).sort(), ['harness', 'project']);
+    assert.equal(new Set(result.sessions.map(({ sessionHash }) => sessionHash)).size, 2);
+    // A Pi agent directory is accepted too, and resolves to its sessions/
+    // child only, so the nested walk cannot read the same file twice.
+    assert.deepEqual(getPiSessionDirs([agentDir]), [agentSessions]);
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi rejects an extra root with no sessions and skips one that disappears', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-invalid-'));
+  const previous = process.env.VIBE_USAGE_PI_SESSION_DIRS;
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    const empty = join(root, 'empty');
+    mkdirSync(empty, { recursive: true });
+    assert.equal(validateExtraRoot('pi-coding-agent', empty).ok, false);
+    assert.equal(validateExtraRoot('pi-coding-agent', join(root, 'missing')).ok, false);
+
+    // A configured root that vanishes must not report an empty result: that
+    // would prune already-uploaded state and force a full re-upload.
+    const result = await parsePi({ extraRoots: [join(root, 'missing')] });
+    assert.equal(result.skipped, true);
+    assert.deepEqual(result.buckets, []);
+    assert.match(result.warnings.join('\n'), /额外根目录不可用/);
+  } finally {
+    restoreEnv('VIBE_USAGE_PI_SESSION_DIRS', previous);
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/pi-compatible.test.js
+++ b/test/pi-compatible.test.js
@@ -7,7 +7,7 @@ import { parse as parseCraftAgent } from '../src/parsers/craft-agent.js';
 import { parse as parseOmp } from '../src/parsers/omp.js';
 import { parse as parsePi } from '../src/parsers/pi-coding-agent.js';
 import { getOmpSessionDirs, getPiSessionDirs } from '../src/pi-roots.js';
-import { validateExtraRoot } from '../src/extra-roots.js';
+import { validateExtraRoot, piSessionsDir } from '../src/extra-roots.js';
 
 const previousCindyDirs = process.env.VIBE_USAGE_CINDY_DIRS;
 process.env.VIBE_USAGE_CINDY_DIRS = join(tmpdir(), 'vibe-usage-cindy-disabled');
@@ -21,6 +21,8 @@ function restoreEnv(name, value) {
   else process.env[name] = value;
 }
 
+// Mirrors a real Pi store: the header carries a full SessionHeader
+// (version/id/timestamp/cwd) and message records carry id/parentId/timestamp.
 function sessionLines({
   sessionId = 'session-1',
   cwd = '/work/project',
@@ -35,16 +37,18 @@ function sessionLines({
       updatedAt: '2026-07-27T13:19:56.000Z',
       pad: '',
     }] : []),
-    { type: 'session', id: sessionId, timestamp: '2026-07-27T13:19:57.000Z', cwd },
+    { type: 'session', version: 3, id: sessionId, timestamp: '2026-07-27T13:19:57.000Z', cwd },
     {
       type: 'message',
       id: 'user-1',
+      parentId: sessionId,
       timestamp: '2026-07-27T13:20:00.000Z',
       message: { role: 'user', content: [] },
     },
     {
       type: 'message',
       id: 'assistant-1',
+      parentId: 'user-1',
       timestamp: '2026-07-27T13:20:05.000Z',
       message: {
         role: 'assistant',
@@ -310,7 +314,7 @@ test('Pi scans an explicitly configured extra session root that discovery cannot
 // contain usage records with no `obj.id`, which record-level dedup cannot see.
 function anonymousSessionLines({ sessionId = 'anonymous-1', input = 10 } = {}) {
   return [
-    { type: 'session', id: sessionId, timestamp: '2026-07-27T13:19:57.000Z', cwd: '/work/project' },
+    { type: 'session', version: 3, id: sessionId, timestamp: '2026-07-27T13:19:57.000Z', cwd: '/work/project' },
     {
       type: 'message',
       timestamp: '2026-07-27T13:20:05.000Z',
@@ -374,6 +378,127 @@ test('Pi extra-root validation requires real Pi session files, not just .jsonl',
     writeFileSync(join(nested, 'session-1.jsonl'), sessionLines({ sessionId: 'session-1' }));
     assert.equal(validateExtraRoot('pi-coding-agent', join(root, 'container')).ok, true);
   } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi extra-root validation rejects malformed Pi lookalikes that parse to zero', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-malformed-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    // Matching on the `type` name alone accepted both of these. Pi's session
+    // format requires a full SessionHeader, and a message record carries
+    // id/parentId/timestamp plus a role the parser consumes — so each of these
+    // would have been stored as a valid root that forever syncs zero.
+    const samples = {
+      'header-without-fields': '{"type":"session"}\n',
+      'message-without-fields': '{"type":"message","message":{}}\n',
+      // A role the parser produces neither usage nor an event for.
+      'unsupported-role': JSON.stringify({
+        type: 'message',
+        id: 'm1',
+        parentId: 's1',
+        timestamp: '2026-07-27T13:20:05.000Z',
+        message: { role: 'system', content: [] },
+      }) + '\n',
+    };
+    for (const [name, body] of Object.entries(samples)) {
+      const dir = join(root, name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'store.jsonl'), body);
+      assert.equal(validateExtraRoot('pi-coding-agent', dir).ok, false, name);
+      // Confirm the rejection matches reality: the parser reads nothing here.
+      const result = await parsePi({ extraRoots: [dir] });
+      assert.deepEqual(result.buckets, [], name);
+    }
+
+    // A complete header still validates, and so does a header-less store whose
+    // message records carry the base fields (an appended-to third-party store).
+    const headerless = join(root, 'headerless');
+    mkdirSync(headerless, { recursive: true });
+    writeFileSync(join(headerless, 'store.jsonl'), JSON.stringify({
+      type: 'message',
+      id: 'assistant-1',
+      parentId: 'user-1',
+      timestamp: '2026-07-27T13:20:05.000Z',
+      message: {
+        role: 'assistant',
+        model: 'test-model',
+        usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    }) + '\n');
+    assert.equal(validateExtraRoot('pi-coding-agent', headerless).ok, true);
+    const parsed = await parsePi({ extraRoots: [headerless] });
+    assert.equal(parsed.buckets.length, 1);
+    assert.equal(parsed.buckets[0].inputTokens, 10);
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi keeps scanning a bare store when an unrelated sessions/ child appears', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-bare-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    // The shape `pi --session <file>` writes: session files in the root itself.
+    const store = join(root, 'store');
+    mkdirSync(store, { recursive: true });
+    writeFileSync(join(store, 's1.jsonl'), anonymousSessionLines({ input: 10 }));
+    assert.equal(piSessionsDir(store), store);
+    const before = await parsePi({ extraRoots: [store] });
+    assert.equal(before.buckets[0].inputTokens, 10);
+
+    // Preferring a readable `sessions/` by name alone meant this bare mkdir
+    // silently redirected the scan to an empty directory: a successful sync
+    // reporting zero, which prunes the source's already-uploaded state.
+    mkdirSync(join(store, 'sessions'));
+    assert.equal(piSessionsDir(store), store);
+    const after = await parsePi({ extraRoots: [store] });
+    assert.equal(after.skipped, undefined);
+    assert.equal(after.buckets[0].inputTokens, 10);
+
+    // The same name-only preference rejected a mixed store outright, even
+    // though its root plainly holds sessions. Canonical-path dedup in the
+    // parser keeps the recursive read from counting the nested file twice.
+    const mixed = join(root, 'mixed');
+    const mixedNested = join(mixed, 'sessions');
+    mkdirSync(mixedNested, { recursive: true });
+    writeFileSync(join(mixed, 'root.jsonl'), anonymousSessionLines({ sessionId: 'r', input: 10 }));
+    writeFileSync(join(mixedNested, 'nested.jsonl'), anonymousSessionLines({ sessionId: 'n', input: 7 }));
+    assert.equal(validateExtraRoot('pi-coding-agent', mixed).ok, true);
+    assert.equal(piSessionsDir(mixed), mixed);
+    const mixedResult = await parsePi({ extraRoots: [mixed] });
+    assert.equal(mixedResult.skipped, undefined);
+    assert.equal(
+      mixedResult.buckets.reduce((sum, { inputTokens }) => sum + inputTokens, 0),
+      17,
+    );
+
+    // An agent home is still resolved to its confirmed sessions/ child.
+    const agentDir = join(root, 'agent');
+    const agentSessions = join(agentDir, 'sessions');
+    mkdirSync(agentSessions, { recursive: true });
+    writeFileSync(join(agentSessions, 's1.jsonl'), sessionLines({ sessionId: 'agent-1' }));
+    assert.equal(piSessionsDir(agentDir), agentSessions);
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/pi-compatible.test.js
+++ b/test/pi-compatible.test.js
@@ -161,9 +161,11 @@ test('OMP discovers XDG profiles and does not also label its agent store as Pi',
     assert.ok(ompDirs.includes(overriddenSession));
     assert.deepEqual(getPiSessionDirs(), []);
     // The OMP guard suppresses discovery of an OMP store as Pi; it must not
-    // discard a root the user added explicitly.
+    // discard a root the user added explicitly. The root has to be a real
+    // store: `add-root` never persists a directory holding no Pi sessions.
     const piStore = join(root, 'pi-sessions');
     mkdirSync(piStore, { recursive: true });
+    writeFileSync(join(piStore, 'session-explicit.jsonl'), sessionLines({ sessionId: 'explicit' }));
     assert.deepEqual(getPiSessionDirs([piStore]), [piStore]);
   } finally {
     for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
@@ -298,6 +300,111 @@ test('Pi scans an explicitly configured extra session root that discovery cannot
     // A Pi agent directory is accepted too, and resolves to its sessions/
     // child only, so the nested walk cannot read the same file twice.
     assert.deepEqual(getPiSessionDirs([agentDir]), [agentSessions]);
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// A store written by a harness that only ever appends (or by an older Pi) can
+// contain usage records with no `obj.id`, which record-level dedup cannot see.
+function anonymousSessionLines({ sessionId = 'anonymous-1', input = 10 } = {}) {
+  return [
+    { type: 'session', id: sessionId, timestamp: '2026-07-27T13:19:57.000Z', cwd: '/work/project' },
+    {
+      type: 'message',
+      timestamp: '2026-07-27T13:20:05.000Z',
+      message: {
+        role: 'assistant',
+        model: 'test-model',
+        usage: { input, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    },
+  ].map((line) => JSON.stringify(line)).join('\n') + '\n';
+}
+
+test('Pi skips a configured agent root whose sessions/ child disappears', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-shape-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    const agentDir = join(root, 'agent');
+    const agentSessions = join(agentDir, 'sessions');
+    mkdirSync(agentSessions, { recursive: true });
+    writeFileSync(join(agentSessions, 'session-1.jsonl'), sessionLines({ sessionId: 'session-1' }));
+    assert.equal(validateExtraRoot('pi-coding-agent', agentDir).ok, true);
+
+    const before = await parsePi({ extraRoots: [agentDir] });
+    assert.equal(before.skipped, undefined);
+    assert.equal(before.buckets.length, 1);
+
+    // Only the nested sessions/ goes away; the configured root itself stays.
+    // Resolving to the root instead would report an empty-but-successful sync
+    // and prune the incremental state for a store that is still configured.
+    rmSync(agentSessions, { recursive: true, force: true });
+    const after = await parsePi({ extraRoots: [agentDir] });
+    assert.equal(after.skipped, true);
+    assert.deepEqual(after.buckets, []);
+    assert.match(after.warnings.join('\n'), /额外根目录不可用/);
+  } finally {
+    for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi extra-root validation requires real Pi session files, not just .jsonl', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-shape-check-'));
+  try {
+    const notPi = join(root, 'unrelated-logs');
+    mkdirSync(notPi, { recursive: true });
+    writeFileSync(join(notPi, 'events.jsonl'), '{"kind":"not-a-pi-session"}\n');
+    // Accepting this would persist a root the parser then ignores in silence,
+    // which is the failure mode extra roots exist to remove.
+    assert.equal(validateExtraRoot('pi-coding-agent', notPi).ok, false);
+
+    const nested = join(root, 'container', 'task-1');
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, 'session-1.jsonl'), sessionLines({ sessionId: 'session-1' }));
+    assert.equal(validateExtraRoot('pi-coding-agent', join(root, 'container')).ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Pi counts an anonymous record once when extra roots overlap', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'vibe-usage-pi-extra-root-overlap-'));
+  const previous = Object.fromEntries([
+    'VIBE_USAGE_PI_SESSION_DIRS',
+    'PI_CODING_AGENT_DIR',
+    'PI_CODING_AGENT_SESSION_DIR',
+  ].map((name) => [name, process.env[name]]));
+  try {
+    delete process.env.VIBE_USAGE_PI_SESSION_DIRS;
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, 'no-default-store');
+
+    const parent = join(root, 'store');
+    const child = join(parent, 'nested');
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(child, 'session-anonymous.jsonl'), anonymousSessionLines({ input: 10 }));
+    // Both shapes validate on their own, so a user can legitimately end up with
+    // an ancestor and a descendant configured at the same time.
+    assert.equal(validateExtraRoot('pi-coding-agent', parent).ok, true);
+    assert.equal(validateExtraRoot('pi-coding-agent', child).ok, true);
+    assert.deepEqual(getPiSessionDirs([parent, child]), [parent, child]);
+
+    const result = await parsePi({ extraRoots: [parent, child] });
+    assert.equal(result.skipped, undefined);
+    assert.equal(result.buckets.length, 1);
+    assert.equal(result.buckets[0].inputTokens, 10);
+    assert.equal(result.sessions.length, 1);
   } finally {
     for (const [name, value] of Object.entries(previous)) restoreEnv(name, value);
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## 背景

延续 #70（Codex / Grok / Antigravity 多个额外数据根）与 #71（pi 的 reasoning 字段与 pi 自身 session 目录配置）。

pi 每次调用都可以用 `--session <file>` 指定单个会话文件，因此 harness 可以把会话写在一个 **pi 自身配置也记录不到** 的目录里：`PI_CODING_AGENT_DIR`、`PI_CODING_AGENT_SESSION_DIR`、`settings.json` 的 `sessionDir` 三者都不包含这个路径。#71 补齐的是后两者，覆盖不到这一种。

Multica / Rollica 的 daemon 正是这种形态：它跑 `pi -p --mode json --session <file>`，文件落在 `~/.multica/pi-sessions/`，并用该文件路径当作跨轮 resume id。和 #70 描述的隔离 Runtime 是同一类问题，只是 pi 不在 #70 的覆盖范围内。

失效方式是静默的：默认 store 仍然能正常解析，所以 pi 被识别为 installed、也有数据，只是数字偏小。本机实测默认 store 只有 21 buckets / 1,594,276 token，而实际另有 116 buckets / 200 sessions / 236,266,512 token（**99.3%**）从未被扫描。

> 口径说明：本文所有 token 数都是 `inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens` 的**各类别合计（含 cache read）**，不是 bucket 的 `totalTokens` 字段——后者按现有 bucket 契约不含 `cachedInputTokens`，同一批数据下为 19,593,153。

## 改动

不新增机制，把 #70 已有的 `extraRoots` 扩展到 `pi-coding-agent`：

- `EXTRA_ROOT_SOURCES` 增加 `pi-coding-agent`（与 parser / state 的 source key 一致，`config.extraRoots[source]` 因此无需在 `sync.js` 做任何特殊处理）。
- 配置的根目录接受两种形态：**直接包含会话 `.jsonl` 的目录**（harness store 上面没有 agent home），或**包含 `sessions/` 的 pi agent 目录**。
- **形态一律按内容判定，不按目录名判定。** 每个根**只解析出一个目录**：根目录直接含已确认的会话文件 → 根；否则 `sessions/` 子目录经内容确认、且根下没有别的子树含会话 → 该子目录；否则根递归确认（容器形态）→ 根；都没有 → null。只按名字优先 `sessions/` 会有两种静默漏算：一个空的 `mkdir <root>/sessions` 就能把 bare store 的扫描劫持成 0；容器根下只要有一支恰好叫 `sessions`，其余任务 store 会被整片遮蔽。`pi-session-jsonl.js` 的遍历是递归的，同时返回某个根和它的 `sessions/` 子目录会把同一批文件读两遍；没有 `obj.id` 的匿名记录不会被 `entriesById` 去重，因此这里刻意避免重叠而不是依赖去重。
- **形态在每次运行时重新判定，无法判定就返回 null，不回退到根本身。** 回退会让一个「丢了 `sessions/` 子目录、但自身仍存在」的 agent 目录变成「可读、但一个会话都没有」，从而报告一次成功的空同步并裁掉仍在配置中的 store 的增量状态。
- **内容探测是三态（`found` / `absent` / `unreadable`），不是布尔。** 布尔把「已确认没有会话」和「读不到、无法确认」压成同一个 `false`，于是「根下有没有别的子树含会话」这个判断会被一次可读性失败误导：容器根下只要有一支任务 store 临时不可读（如 `chmod 000`），它就会被当成「不含会话」，容器随即被判成 agent 形态并收窄到 `sessions/`，其余任务 store 被静默裁掉且不带 `skipped`。三态下 `found` 优先于 `unreadable`（一条确认会话足以定形，剩下读不到的部分由共享 parser 自己报 `skipped`），`unreadable` 优先于 `absent`；而所有依赖「不存在」的判断遇到 `unreadable` 一律放弃定形、返回 null，由调用方 `skipped`。文件级同理：打不开的 `.jsonl` 是「读不到」，不是「不是会话」。
- **额外在 `parsePiSessionJsonl()` 内按 canonical file path 去重。** 「每个根只解析一个目录」只消除 agent-home ↔ `sessions/` 这一种重叠；两个配置项之间仍可能是父子关系，或通过符号链接指向同一个文件，而匿名记录事后无法去重。
- 默认发现行为不变、始终扫描；配置的根是追加。OMP guard（`PI_CODING_AGENT_DIR` 指向可识别的 OMP store 时不把它当 pi）仍然抑制**发现**，但不再丢掉用户显式添加的根——显式配置不应该被静默忽略。
- 配置的根暂时不可读时返回 `skipped`（对齐 grok 的处理），避免增量状态被裁剪、进而触发全量重传。这条保证覆盖的不只是「根本身消失」：根仍可读、但其下任一候选子树或候选文件读不到时，也不允许被解释成「那里没有会话」。
- `config add-root` 校验要求两层内存在**真正的 pi 会话文件**：读取候选 `.jsonl` 的前 16 KB，并按 pi 的 `docs/session-format.md` 做**结构校验**——完整 `SessionHeader`（`type: "session"` + `version` + 非空 `id`/`timestamp` + 字符串 `cwd`），或一条完整的 message 记录（非空 `id`、存在 `parentId`、非空 `timestamp`，且 `message.role` ∈ `user`/`assistant`/`toolResult`，兼容无 header 的第三方 store）。`version` 只校验存在不校验类型：真实 store 里它既写成数字 `3` 也写成字符串 `"3"`。只看扩展名会把无关日志目录存进配置；只匹配 `type` 名字则会放过 `{"type":"session"}`、`{"type":"message","message":{}}` 这类 parser 读出来恒为 0 的畸形样本——两者都是本 PR 要消灭的失效模式。
- `config add-root` / `remove-root` 的 usage 文本改为从 `EXTRA_ROOT_SOURCES` 生成，避免以后再次漂移。

`VIBE_USAGE_PI_SESSION_DIRS` 语义不变（仍是 fixture/relocation override、替换发现结果）；配置的根在设置了该变量时同样生效，因为它属于用户显式配置而非 fixture。如果你们希望与 `findGrokDataDirs` 完全对齐（override 时忽略 extraRoots），我改掉即可。

没有修改 source 命名、hostname、隐私策略、后端接口、上传结构或 reset 语义。

## 关于 Architecture Approval Gate

`extraRoots` 这个控制面本身已由 #70 落地并合并（maintainer co-author），本 PR 只是把已批准的机制多覆盖一个 source，没有引入新的 invariant，因此按 AGENTS.md 我理解不属于需要重新审批的架构变更。若你们判断仍需单独批准，我可以拆成 RFC issue 或把实现部分单独摘出来。

- current invariant：`extraRoots` 支持 codex / grok / antigravity；pi 只能通过发现或无文档的 `VIBE_USAGE_PI_SESSION_DIRS` 扫描。
- proposed invariant：`extraRoots` 增加 `pi-coding-agent`，默认目录始终保留，额外目录仅在显式添加后参与扫描。
- 兼容性：未配置该 key 的用户行为完全不变；旧版本 CLI 会忽略这个 key。
- 回滚：删除 `config.extraRoots['pi-coding-agent']` 即恢复原行为。

## 验证

- `npm test`：216 / 216 通过（在 `main` 的 206 之上新增 10 个测试）。
- 真实数据（本机 Multica/Rollica runtime 的 `~/.multica/pi-sessions`）：配置根得到 **116 buckets / 200 sessions / 236,266,512 token**，与用 `VIBE_USAGE_PI_SESSION_DIRS` 走同一 store 的结果完全一致；默认 store 单独为 21 buckets / 1,594,276 token。
- 把 pi agent 目录本身作为根传入，结果与只扫默认目录**完全相同**（21 buckets / 1,594,276 token），确认递归遍历没有重复读取。
- 边界回归都有测试覆盖：agent 目录的 `sessions/` 中途消失 → `skipped` 而不是空结果；内容为 `{"kind":"not-a-pi-session"}` 的 `events.jsonl` → `add-root` 拒绝；父子重叠的两个根 → 同一条匿名记录只计一次（修复前算两次）；bare store 旁边出现空 `sessions/` → 仍然扫描根本身；混合根（根 10 + `sessions/` 7）→ 合计 17；容器根下一支任务 store 恰好叫 `sessions`（`task-a/` 10 + `sessions/` 7）→ 合计 17，不是被遮蔽后的 7；同一容器把 `task-a` 单独 `chmod 000`（根与 `sessions/` 仍可读）→ `skipped === true` 且不产出部分结果，权限恢复后重新得到 17；根目录下有一个打不开的 `.jsonl`、旁边是已确认的 `sessions/` → 同样 `skipped`，不收窄到 `sessions/`；三个畸形 lookalike（缺字段的 header、空 `message`、`role: system`）→ `add-root` 拒绝，且同时断言 parser 确实读不出任何 bucket。
- 通过真实 CLI 验证 `config add-root pi-coding-agent <dir>` → `config roots` → `status` 中 pi 被识别；空目录、不存在的目录、非 pi 的 `.jsonl` 目录均被拒绝并给出原因。
- 全程只读解析，未触发上传。

## 后续（本 PR 未做）

`omp` 是同一类形态（也走 pi 的 JSONL），目前同样不在 `extraRoots` 覆盖范围内。为控制本 PR 的评审范围没有一起加，需要的话我另开一个。


