### PR TITLE
fix(kimi-code): resolve secondary agent model alias

### DIFF
--- a/src/parsers/kimi-code.js
+++ b/src/parsers/kimi-code.js
@@ -158,6 +158,8 @@ function parseKimiCode() {
     }
 
     const project = sessionIndex.get(sessionDir) || bucketProject || 'unknown';
+    let lastRequestModel = null;
+    let lastRequestAlias = null;
 
     for (const line of content.split('\n')) {
       if (!line.trim()) continue;
@@ -165,6 +167,19 @@ function parseKimiCode() {
       try { evt = JSON.parse(line); } catch { continue; }
 
       const type = evt.type;
+      // `usage.record.model` may contain the configured alias rather than the
+      // provider model. The preceding `llm.request` carries both values, so
+      // retain the real model for resolving aliases such as `__secondary__`.
+      if (type === 'llm.request') {
+        lastRequestModel = typeof evt.model === 'string' && evt.model.trim()
+          ? evt.model.trim()
+          : null;
+        lastRequestAlias = typeof evt.modelAlias === 'string' && evt.modelAlias.trim()
+          ? evt.modelAlias.trim()
+          : null;
+        continue;
+      }
+
       // Top-level `time` is integer milliseconds since epoch. Validate it:
       // JSON numbers can overflow to Infinity (e.g. 1e400 parses fine), and
       // any out-of-range value yields an Invalid Date that later crashes
@@ -204,9 +219,19 @@ function parseKimiCode() {
       const cachedInputTokens = usageTokens(usage.inputCacheRead);
       if (!inputTokens && !outputTokens && !cachedInputTokens) continue;
 
+      const reportedModel = typeof evt.model === 'string' && evt.model.trim()
+        ? evt.model.trim()
+        : null;
+      const isAlias = reportedModel && (
+        reportedModel === '__secondary__' || reportedModel === lastRequestAlias
+      );
+      const model = isAlias && lastRequestModel
+        ? lastRequestModel
+        : reportedModel || lastRequestModel || 'unknown';
+
       entries.push({
         source: 'kimi-code',
-        model: evt.model || 'unknown',
+        model,
         project,
         timestamp: ts,
         inputTokens,

--- a/test/kimi-code.test.js
+++ b/test/kimi-code.test.js
@@ -16,10 +16,10 @@ const { parse } = await import('../src/parsers/kimi-code.js');
 
 after(() => rmSync(root, { recursive: true, force: true }));
 
-function usage(time, usageScope, values) {
+function usage(time, usageScope, values, model = 'kimi-code/k3') {
   return {
     type: 'usage.record',
-    model: 'kimi-code/k3',
+    model,
     usage: {
       inputOther: 0,
       output: 0,
@@ -108,4 +108,56 @@ test('current Kimi parser counts all delta scopes, cache creation, and subagents
     userMessageCount: 1,
     userPromptHours: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   });
+});
+
+test('current Kimi parser resolves Secondary Agent aliases to the request model', async () => {
+  const sessionDir = join(currentRoot, 'sessions', 'wd_secondary_abcd', 'session_secondary');
+  const mainDir = join(sessionDir, 'agents', 'main');
+  mkdirSync(mainDir, { recursive: true });
+
+  const start = Date.parse('2026-07-18T00:01:00.000Z');
+  const records = [
+    { type: 'turn.prompt', origin: { kind: 'user' }, time: start },
+    {
+      type: 'llm.request',
+      model: 'provider-secondary-v2',
+      modelAlias: '__secondary__',
+      provider: 'anthropic',
+      time: start,
+    },
+    usage(start + 60_000, 'turn', {
+      inputOther: 10,
+      output: 2,
+    }, '__secondary__'),
+    {
+      type: 'llm.request',
+      model: 'provider-secondary-v3',
+      modelAlias: '__secondary__',
+      provider: 'another-provider',
+      time: start + 120_000,
+    },
+    usage(start + 180_000, 'turn', {
+      inputOther: 5,
+      output: 1,
+    }, '__secondary__'),
+  ];
+  writeFileSync(join(mainDir, 'wire.jsonl'), `${records.map(JSON.stringify).join('\n')}\n`, 'utf-8');
+
+  const result = await parse();
+  const secondary = result.buckets.find((bucket) => (
+    bucket.project === 'secondary'
+    && bucket.model === 'provider-secondary-v2'
+  ));
+  const switchedSecondary = result.buckets.find((bucket) => (
+    bucket.project === 'secondary'
+    && bucket.model === 'provider-secondary-v3'
+  ));
+
+  assert.equal(secondary?.inputTokens, 10);
+  assert.equal(secondary?.outputTokens, 2);
+  assert.equal(switchedSecondary?.inputTokens, 5);
+  assert.equal(switchedSecondary?.outputTokens, 1);
+  assert.equal(result.buckets.some((bucket) => (
+    bucket.project === 'secondary' && bucket.model === '__secondary__'
+  )), false);
 });


### PR DESCRIPTION
## Summary

- Resolve Kimi Code Secondary Agent usage aliases from the corresponding `llm.request.model`.
- Preserve the reported model as a safe fallback when matching request metadata is unavailable.
- Add regression coverage for non-M3 Secondary Agent models and model switching within one session.

Closes #78

## Testing

- `npm test` — 217 passed
- `git diff --check` — passed