### PR TITLE
feat(cli): status / init 显示 key 绑在哪个账号名下

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -281,6 +281,39 @@ export function getJson(apiUrl, apiKey, path, { timeoutMs = 15_000 } = {}) {
 }
 
 /**
+ * Which vibecafe account this API key is bound to.
+ *
+ * Exists because a key minted against the wrong account is otherwise invisible
+ * from the client side: ingest and this endpoint both answer 200 for it, so the
+ * user sees a healthy CLI and a healthy desktop app while their uploads pile up
+ * on an account they never look at. Ask the backend whose data it is and say so.
+ *
+ * Returns null when the backend is too old to send `account`, or on any
+ * transient failure — identity is a nicety, never a reason to fail a command.
+ * UNAUTHORIZED still propagates: that one the caller must not swallow.
+ *
+ * @param {string} apiUrl
+ * @param {string} apiKey
+ * @returns {Promise<{handle: string, name: string | null} | null>}
+ */
+export async function fetchAccount(apiUrl, apiKey) {
+  let data;
+  try {
+    // bucketsOnly keeps the response to the aggregate we throw away; days=1
+    // keeps the window (and the scan) small.
+    data = await getJson(apiUrl, apiKey, '/api/usage?days=1&bucketsOnly=true', { timeoutMs: 10_000 });
+  } catch (err) {
+    if (err.message === 'UNAUTHORIZED') throw err;
+    return null;
+  }
+  const account = data?.account;
+  if (account && typeof account.handle === 'string') {
+    return { handle: account.handle, name: account.name ?? null };
+  }
+  return null;
+}
+
+/**
  * GET user settings from the vibecafe API.
  * Returns null after transient failures are exhausted. A 401 remains distinct
  * so callers can surface invalid credentials instead of calling it an outage.

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import {
   normalizeExtraRoot,
   validateExtraRoot,
 } from './extra-roots.js';
-import { failure, smallHeader } from './output.js';
+import { dim as dimText, failure, smallHeader, warn } from './output.js';
+import { fetchAccount } from './api.js';
 
 function printSmallHeader() {
   console.log();
@@ -27,6 +28,8 @@ async function showStatus() {
     console.log(`  Config: ${getConfigPath()}`);
     console.log(`  API key: ${config.apiKey.slice(0, 8)}...`);
     console.log(`  API URL: ${config.apiUrl || 'https://vibecafe.ai'}`);
+    // 数据算在谁名下,是这里最该回答、以前偏偏答不出的一件事。
+    await printBoundAccount(config.apiUrl || 'https://vibecafe.ai', config.apiKey);
     if (config.codexExtraHome) {
       console.log(`  Extra Codex Home: ${config.codexExtraHome}`);
     }
@@ -60,6 +63,30 @@ async function showStatus() {
     console.log(`    ${tool.name}: ${installed}`);
   }
   console.log();
+}
+
+/**
+ * Print the account this key uploads to. Never throws: an offline machine or an
+ * older backend just means we cannot name the account, which must not make
+ * `status` fail — but a revoked/invalid key is worth saying out loud.
+ */
+async function printBoundAccount(apiUrl, apiKey) {
+  try {
+    const account = await fetchAccount(apiUrl, apiKey);
+    if (account) {
+      const label = account.name ? `@${account.handle}(${account.name})` : `@${account.handle}`;
+      console.log(`  账号: ${label}`);
+      console.log(dimText(`        数据都记在这个账号名下,不是它就换个账号重新 init`));
+    } else {
+      console.log(dimText('  账号: 服务端未返回(后端版本较旧或网络异常)'));
+    }
+  } catch (err) {
+    if (err.message === 'UNAUTHORIZED') {
+      console.log(warn('账号: Key 已失效,请重新运行 `npx @vibe-cafe/vibe-usage init`'));
+      return;
+    }
+    console.log(dimText('  账号: 读取失败'));
+  }
 }
 
 const VALID_CONFIG_KEYS = ['apiKey', 'apiUrl', 'hostname', 'codexExtraHome'];

--- a/src/init.js
+++ b/src/init.js
@@ -2,7 +2,7 @@ import { createInterface } from 'node:readline';
 import { execFile } from 'node:child_process';
 import { hostname as osHostname, platform } from 'node:os';
 import { loadConfig, saveConfig } from './config.js';
-import { ingest, requestDeviceCode, pollDeviceCode } from './api.js';
+import { fetchAccount, ingest, requestDeviceCode, pollDeviceCode } from './api.js';
 import { runSync } from './sync.js';
 import { detectInstalledTools } from './tools.js';
 import { bigHeader, success, failure, warn, arrow, link, dim, divider } from './output.js';
@@ -68,6 +68,13 @@ export async function runInit(options = {}) {
   try {
     await ingest(apiUrl, apiKey, []);
     console.log(success(`验证通过 ${dim(apiKey.slice(0, 12) + '...')}`));
+    // 说清楚数据会算在谁名下 —— 授权那一刻浏览器里登录的可能并不是他自己以为的
+    // 那个账号,而这是整条链路上最后一次能当场发现的机会。
+    const account = await fetchAccount(apiUrl, apiKey).catch(() => null);
+    if (account) {
+      console.log(success(`已链接到账号 ${account.name ? `@${account.handle}(${account.name})` : `@${account.handle}`}`));
+      console.log(dim('  数据都会记在这个账号名下;不是你要的账号就退出登录后重新 init。'));
+    }
   } catch (err) {
     if (err.message === 'UNAUTHORIZED') {
       console.error(failure('API Key 无效，请检查后重试。'));

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import { gunzipSync } from 'node:zlib';
-import { encodeIngestBody, fetchSettings, retryDelayMs } from '../src/api.js';
+import { encodeIngestBody, fetchAccount, fetchSettings, retryDelayMs } from '../src/api.js';
 
 async function withServer(handler, run) {
   const server = createServer(handler);
@@ -93,4 +93,38 @@ test('fetchSettings does not retry an invalid API key', async () => {
     );
   });
   assert.equal(requests, 1);
+});
+
+test('fetchAccount names the account a key is bound to', async () => {
+  let seenPath = null;
+  const account = await withServer((req, res) => {
+    seenPath = req.url;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ account: { handle: 'milky2018', name: '布丁大魔王' }, buckets: [] }));
+  }, url => fetchAccount(url, 'vbu_test'));
+
+  assert.deepEqual(account, { handle: 'milky2018', name: '布丁大魔王' });
+  // Cheapest shape of the call: one day, aggregate only.
+  assert.equal(seenPath, '/api/usage?days=1&bucketsOnly=true');
+});
+
+test('fetchAccount stays null against an older backend or a transient failure', async () => {
+  const missingField = await withServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ buckets: [] }));
+  }, url => fetchAccount(url, 'vbu_test'));
+  assert.equal(missingField, null);
+
+  const serverError = await withServer((_req, res) => {
+    res.writeHead(500).end('boom');
+  }, url => fetchAccount(url, 'vbu_test'));
+  assert.equal(serverError, null);
+});
+
+test('fetchAccount still surfaces an invalid key', async () => {
+  await withServer((_req, res) => {
+    res.writeHead(401).end('nope');
+  }, async url => {
+    await assert.rejects(() => fetchAccount(url, 'vbu_bad'), /UNAUTHORIZED/);
+  });
 });


### PR DESCRIPTION
## 为什么

绑错账号在客户端这一侧**完全看不出来**：ingest 和 `/api/usage` 对一把绑到别人账号上的 key 一样返回 200，于是 CLI 显示「已同步」、桌面 App 里有数据（App 的数字本来就是从服务端拉的），用户只在网页上看到空白 —— 两边都以为是对方的 bug。两位 999 成员因此各自把两个多月的用量传丢在一个自己从不打开的账号里，其中一位断了 2.5 个月才被发现。

## 改了什么

- `api.js` 新增 `fetchAccount()`：读后端的 `account` 字段（vibe-cafe PR #167，需先上线）。后端版本旧或网络异常一律返回 `null` —— 身份是锦上添花，不该让命令失败；只有 `UNAUTHORIZED` 继续抛出。
- `status`：在 API key 下面打印「账号: @handle（名字）」；Key 失效时明确提示重新 `init`。
- `init`：验证通过后打印「已链接到账号 @handle」。授权那一刻浏览器里登录的是谁，这是整条链路上最后一次能当场发现的机会。

`sync` 刻意不加这次请求：每 30 分钟一次的后台同步不值得为一行提示多打一次聚合查询。

## 验证

`npm test` 全绿（235 pass / 19 skipped / 0 fail），其中新增三条 `fetchAccount` 用例覆盖：正常返回、老后端缺字段与 5xx 时返回 `null`、401 仍然抛出。

## 发布顺序

后端 PR 先合并部署（否则 `account` 字段不存在，CLI 只是不显示账号，不会报错），再 `chore: release v0.10.23` + `npm publish`。版本号本 PR 没有动，留给发布提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3wV99bEQZgywb7GFj1oQa
