### PR TITLE
feat(summary): 加「按工具」表，按费用降序

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ vibe-usage/
 │   ├── sync.js                # Orchestrator: parse all → diff vs state → batch upload only new/changed
 │   ├── state.js               # ~/.vibe-usage/state.json: key→hash of uploaded items (incremental sync), clearState() for reset
 │   ├── api.js                 # HTTP client: ingest() (always gzip), requestDeviceCode()/pollDeviceCode() (device flow), deleteAllData(), fetchSettings()
-│   ├── summary.js             # `summary --days N`: GET /api/usage with the saved vbu_ key, render markdown (cost / tokens / by-model / by-project). Powers the SKILL.md "查询用量" entries.
+│   ├── summary.js             # `summary --days N`: GET /api/usage with the saved vbu_ key, render markdown (cost / tokens / by-tool / by-model / by-project, each table cost-desc). Powers the SKILL.md "查询用量" entries.
 │   ├── config.js              # ~/.vibe-usage/config.json (dev: config.dev.json)
 │   ├── init.js                # Setup flow (device-flow browser login by default; --manual-key for CI/headless, verify, initial sync, then installs the background service unless --no-daemon / non-TTY)
 │   ├── daemon.js              # 30-minute sync loop (foreground)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npx @vibe-cafe/vibe-usage init         # Re-run setup via browser login (also ho
 npx @vibe-cafe/vibe-usage init --manual-key <vbu_...>   # Skip browser, use pre-issued key (CI/headless)
 npx @vibe-cafe/vibe-usage sync         # Manual sync
 npx @vibe-cafe/vibe-usage sync --extra-codex-home /path/to/.codex  # Add another Codex Home for this run only
-npx @vibe-cafe/vibe-usage summary       # Print last 7 days as markdown (cost / tokens / by model / by project)
+npx @vibe-cafe/vibe-usage summary       # Print last 7 days as markdown (cost / tokens / by tool / by model / by project)
 npx @vibe-cafe/vibe-usage summary --days N  # Same, over the last N days (1-90)
 npx @vibe-cafe/vibe-usage daemon       # Continuous sync (every 30m, foreground)
 npx @vibe-cafe/vibe-usage daemon install    # Install background service (systemd/launchd/Task Scheduler)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibe-cafe/vibe-usage",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibe-cafe/vibe-usage",
-      "version": "0.10.29",
+      "version": "0.10.30",
       "license": "MIT",
       "bin": {
         "vibe-usage": "bin/vibe-usage.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-cafe/vibe-usage",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "description": "Track your AI coding tool token usage and sync to vibecafe.ai",
   "type": "module",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,7 @@ const FULL_HELP = `
     ${BARE} init --manual-key <vbu_...>   Skip browser, use a pre-issued key (CI/headless)
     ${BARE} sync         Manually sync usage data
     ${BARE} sync --extra-codex-home <path>  Use another Codex Home for this run
-    ${BARE} summary       Print last 7 days as markdown (cost/tokens/model/project)
+    ${BARE} summary       Print last 7 days as markdown (cost/tokens/tool/model/project)
     ${BARE} summary --days N   Same, but over the last N days (1-90)
     ${BARE} daemon       Continuous sync (every 30m, foreground)
     ${BARE} daemon install    Install background service (systemd/launchd/Task Scheduler)

--- a/src/summary.js
+++ b/src/summary.js
@@ -1,6 +1,12 @@
 import { loadConfig } from './config.js';
 import { getJson } from './api.js';
 import { failure } from './output.js';
+import { TOOLS } from './tools.js';
+
+// Server-side source ids are raw slugs ('claude-code'); TOOLS carries the
+// display names. A source the server knows but this CLI doesn't parse falls
+// back to its id rather than disappearing from the table.
+const TOOL_NAMES = new Map(TOOLS.map(t => [t.id, t.name]));
 
 export async function runSummary(args = []) {
   const days = parseDays(args);
@@ -36,7 +42,7 @@ function parseDays(args) {
   return v;
 }
 
-function render(data, days, apiUrl) {
+export function render(data, days, apiUrl) {
   const buckets = Array.isArray(data?.buckets) ? data.buckets : [];
   const sessions = Array.isArray(data?.sessions) ? data.sessions : [];
   const dashboard = `${apiUrl}/usage`;
@@ -47,6 +53,7 @@ function render(data, days, apiUrl) {
 
   let totalCost = 0;
   let totalTokens = 0;
+  const bySource = new Map();
   const byModel = new Map();
   const byProject = new Map();
 
@@ -55,6 +62,7 @@ function render(data, days, apiUrl) {
     const tokens = Number(b.totalTokens ?? 0);
     totalCost += cost;
     totalTokens += tokens;
+    accumulate(bySource, b.source || 'unknown', { cost, tokens });
     accumulate(byModel, b.model, { cost, tokens });
     accumulate(byProject, b.project || 'unknown', { cost, tokens, sessions: 0 });
   }
@@ -72,6 +80,16 @@ function render(data, days, apiUrl) {
   lines.push(`# Vibe Usage Summary (Last ${days} ${days === 1 ? 'day' : 'days'})`);
   lines.push('');
   lines.push(`**总览**: $${totalCost.toFixed(2)} · ${formatTokens(totalTokens)} tokens · ${sessionsCount} sessions · ${activeHours.toFixed(1)}h active`);
+  lines.push('');
+
+  lines.push('## 按工具');
+  lines.push('');
+  lines.push('| 工具 | 费用 | Tokens | 占比 |');
+  lines.push('|---|---:|---:|---:|');
+  for (const [source, { cost, tokens }] of topN(bySource, 'cost', 8)) {
+    const pct = totalCost > 0 ? ((cost / totalCost) * 100).toFixed(0) : '0';
+    lines.push(`| ${TOOL_NAMES.get(source) || source} | $${cost.toFixed(2)} | ${formatTokens(tokens)} | ${pct}% |`);
+  }
   lines.push('');
 
   lines.push('## 按模型');

--- a/test/summary.test.js
+++ b/test/summary.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render } from '../src/summary.js';
+
+function bucket(source, model, cost, tokens) {
+  return { source, model, project: '/repo/x', estimatedCost: cost, totalTokens: tokens };
+}
+
+const DATA = {
+  buckets: [
+    bucket('codex', 'gpt-5.5', 12.0, 3_000_000),
+    bucket('alma', 'claude-opus-4.8', 0.5, 100_000),
+    bucket('claude-code', 'claude-opus-4.8', 8.0, 9_000_000),
+    // Unpriced model: lots of volume, no cost — must not outrank paid tools.
+    bucket('mimocode', 'mimo-1', 0, 50_000_000),
+  ],
+  sessions: [],
+};
+
+function toolRows(md) {
+  const body = md.split('## 按工具')[1].split('## 按模型')[0];
+  return body
+    .split('\n')
+    .filter(l => l.startsWith('| ') && !l.startsWith('| 工具') && !l.startsWith('|---'))
+    .map(l => l.split('|')[1].trim());
+}
+
+test('summary has a 按工具 table ordered by cost, biggest first', () => {
+  const md = render(DATA, 7, 'https://vibecafe.ai');
+  assert.match(md, /## 按工具/);
+  assert.deepEqual(toolRows(md), ['Codex CLI', 'Claude Code', 'Alma', 'MiMoCode']);
+});
+
+test('按工具 sits above 按模型 and 按项目', () => {
+  const md = render(DATA, 7, 'https://vibecafe.ai');
+  assert.ok(md.indexOf('## 按工具') < md.indexOf('## 按模型'));
+  assert.ok(md.indexOf('## 按模型') < md.indexOf('## 按项目'));
+});
+
+test('an unknown source falls back to its raw id instead of vanishing', () => {
+  const md = render({ buckets: [bucket('brand-new-tool', 'm', 1, 10)], sessions: [] }, 7, 'x');
+  assert.deepEqual(toolRows(md), ['brand-new-tool']);
+});
+
+test('empty data still short-circuits to the 暂无数据 message', () => {
+  const md = render({ buckets: [], sessions: [] }, 7, 'https://vibecafe.ai');
+  assert.match(md, /暂无数据/);
+  assert.doesNotMatch(md, /## 按工具/);
+});


### PR DESCRIPTION
`summary` 一直有「按模型」「按项目」两张表（都已按费用降序，没问题），却**没有「按工具」**——而 `/api/usage` 返回的每个 bucket 本来就带 `source` 和 `estimatedCost`，聚一下就有。工具维度恰恰是用户最想知道的一维：钱花在 Claude Code 还是 Codex 上。

盘点来源：江昪 2026-09-11 让网页榜单（vibecafe.ai/rank）的分工具榜、分模型榜改按消耗金额排序（vibe-cafe#189），顺带扫了两个仓库里所有按工具／模型展示的列表。CLI 这边没有排序错误，只有这一处缺口。

## 改了什么

```
## 按工具

| 工具 | 费用 | Tokens | 占比 |
|---|---:|---:|---:|
| Codex CLI | $12.00 | 3.0M | 59% |
| Claude Code | $8.00 | 9.0M | 39% |
...
```

- 排在「按模型」之前，复用现成的 `topN(map, 'cost', 8)`，与另两张表同一套口径。
- source id → 展示名走 `TOOLS`（`index.js` 本来就在顶层 import 它，无额外启动开销）；服务端认识但本 CLI 不解析的 source **回落显示原始 id**，不会从表里消失。
- 未定价模型（cost 0）即使 token 量很大也排在付费工具之后，与网页端榜单同口径。
- `render()` 改为导出以便测试；新增 `test/summary.test.js`。

不碰采集、隐私、身份、跨仓契约或自动升级，不触发 AGENTS.md 的 Architecture Approval Gate。服务端无需任何改动（读的是已有字段），与 vibe-cafe#189 无先后依赖。

## 验证

`node --test`：**301 pass / 0 fail**（22 skipped，与 main 一致）。新增 4 个用例，含关键的一条——50M tokens 但 $0 的未定价工具必须排在 $0.50 的付费工具之后，也就是先测「本该被拦下的那一侧」。

版本号 `package.json` 与 `package-lock.json` 已同步到 **0.10.30**（npm 上当前是 0.10.29）。发版只能江昪本人跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D1LCMnrgsQYxWCeDRdX4c
